### PR TITLE
Prefer locally installed version, fall back to global.

### DIFF
--- a/cli-shim.js
+++ b/cli-shim.js
@@ -1,14 +1,10 @@
 #!/usr/bin/env node
 'use strict';
-var resolve = require('resolve');
-
-var cliPath;
-
-try {
-	cliPath = resolve.sync('xo/cli', {basedir: process.cwd()});
-	process.env.NO_UPDATE_NOTIFIER = 1;
-} catch (e) {
-	cliPath = './cli';
-}
-
-require(cliPath);
+require('fallback-cli')({
+	path: 'xo/cli',
+	before: function (location) {
+		if (location === 'local') {
+			process.env.NO_UPDATE_NOTIFIER = 1;
+		}
+	}
+});

--- a/cli-shim.js
+++ b/cli-shim.js
@@ -6,6 +6,7 @@ var cliPath;
 
 try {
 	cliPath = resolve.sync('xo/cli', {basedir: process.cwd()});
+	process.env.NO_UPDATE_NOTIFIER = 1;
 } catch (e) {
 	cliPath = './cli';
 }

--- a/cli-shim.js
+++ b/cli-shim.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+'use strict';
+var resolve = require('resolve');
+
+var cliPath;
+
+try {
+	cliPath = resolve.sync('xo/cli', {basedir: process.cwd()});
+} catch (e) {
+	cliPath = './cli';
+}
+
+require(cliPath);

--- a/package.json
+++ b/package.json
@@ -58,12 +58,12 @@
     "eslint": "^1.4.1",
     "eslint-config-xo": "^0.6.0",
     "eslint-plugin-babel": "^2.1.1",
+    "fallback-cli": "^1.0.2",
     "get-stdin": "^5.0.0",
     "globby": "^3.0.0",
     "meow": "^3.3.0",
     "object-assign": "^4.0.1",
     "pkg-conf": "^1.0.1",
-    "resolve": "^1.1.6",
     "update-notifier": "^0.5.0",
     "xo-init": "^0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com"
   },
-  "bin": "cli.js",
+  "bin": "cli-shim.js",
   "engines": {
     "node": ">=0.10.0"
   },
@@ -62,6 +62,7 @@
     "meow": "^3.3.0",
     "object-assign": "^4.0.1",
     "pkg-conf": "^1.0.1",
+    "resolve": "^1.1.6",
     "update-notifier": "^0.5.0",
     "xo-init": "^0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "files": [
     "index.js",
+    "cli-shim.js",
     "cli.js"
   ],
   "keywords": [


### PR DESCRIPTION
Use whatever version of `xo` is installed locally in `node_modules`, before using the globally installed version.

Fairly naive implementation, but it works and is backward compatible as far back as I checked (0.7.x).

I disable `update-notifier` if a local version is found. That could maybe be improved upon by still notifying if local is out of date. `update-notifier` seems to always recommend installation with the `-g` flag though.