### PR TITLE
Add support for plugins

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,6 +20,7 @@ var cli = meow({
 		'  --ignore        Additional paths to ignore  [Can be set multiple times]',
 		'  --space         Use space indent instead of tabs  [Default: 2]',
 		'  --no-semicolon  Prevent use of semicolons',
+		'  --plugin        Include third-party plugins  [Can be set multiple times]',
 		'',
 		'Examples',
 		'  $ xo',
@@ -28,6 +29,7 @@ var cli = meow({
 		'  $ xo --esnext --space',
 		'  $ xo --env=node --env=mocha',
 		'  $ xo --init --esnext',
+		'  $ xo --plugin=react',
 		'',
 		'Tips',
 		'  Put options in package.json instead of using flags so other tools can read it.'

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function handleOpts(opts) {
 	opts.envs = opts.envs || opts.env;
 	opts.globals = opts.globals || opts.global;
 	opts.ignores = opts.ignores || opts.ignore;
+	opts.plugins = opts.plugins || opts.plugin;
 	opts.rules = opts.rules || opts.rule;
 
 	opts.ignores = DEFAULT_IGNORE.concat(opts.ignores || []);
@@ -43,6 +44,7 @@ function handleOpts(opts) {
 	opts._config = deepAssign({}, DEFAULT_CONFIG, {
 		envs: arrify(opts.envs),
 		globals: arrify(opts.globals),
+		plugins: arrify(opts.plugins),
 		rules: opts.rules
 	});
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "eslint-plugin-react": "^3.5.1",
     "xo": "sindresorhus/xo#v0.9.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ $ xo --help
     --ignore        Additional paths to ignore  [Can be set multiple times]
     --space         Use space indent instead of tabs  [Default: 2]
     --no-semicolon  Prevent use of semicolons
+    --plugin        Include third-party plugins  [Can be set multiple times]
 
   Examples
     $ xo
@@ -66,6 +67,7 @@ $ xo --help
     $ xo --esnext --space
     $ xo --env=node --env=mocha
     $ xo --init --esnext
+    $ xo --plugin=react
 
   Tips
     Put options in package.json instead of using flags so other tools can read it.
@@ -179,6 +181,12 @@ Type: `boolean`
 Default: `true` *(semicolons required)*
 
 Set it to `false` to enforce no-semicolon style.
+
+### plugins
+
+Type: `array`
+
+Include third-party [plugins](http://eslint.org/docs/user-guide/configuring.html#configuring-plugins).
 
 
 ## FAQ

--- a/test.js
+++ b/test.js
@@ -19,4 +19,14 @@ test('.lintText() - JSX support', t => {
 	t.end();
 });
 
+test('.lintText() - plugin support', t => {
+	const results = fn.lintText('var React;\nReact.render(<App/>);\n', {
+		plugins: ['react'],
+		rules: {'react/jsx-no-undef': 2}
+	}).results;
+	t.is(results[0].messages[0].ruleId, 'react/jsx-no-undef');
+	t.is(results[0].messages[0].message, '\'App\' is not defined.');
+	t.end();
+});
+
 // TODO: more tests


### PR DESCRIPTION
Don't know if you had another API in mind, but this at least does the job. If you want, I can include https://github.com/dustinspecker/eslint-plugin-no-use-extend-native/ by default too (like mentioned in #30).

Fixes #30.