### PR TITLE
Use `no-use-extend-native` plugin by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,8 @@ function handleOpts(opts) {
 		opts._config.baseConfig = 'xo/esnext';
 	}
 
+	opts._config.plugins.push('no-use-extend-native');
+
 	return opts;
 }
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint": "^1.4.1",
     "eslint-config-xo": "^0.6.0",
     "eslint-plugin-babel": "^2.1.1",
+    "eslint-plugin-no-use-extend-native": "^0.1.5",
     "get-stdin": "^5.0.0",
     "globby": "^3.0.0",
     "meow": "^3.3.0",

--- a/test.js
+++ b/test.js
@@ -29,4 +29,11 @@ test('.lintText() - plugin support', t => {
 	t.end();
 });
 
+test('.lintText() - prevent use of extended native objects', t => {
+	const results = fn.lintText('[].unicorn();\n').results;
+	t.is(results[0].messages[0].ruleId, 'no-use-extend-native/no-use-extend-native');
+	t.is(results[0].messages[0].message, 'Avoid using extended native objects');
+	t.end();
+});
+
 // TODO: more tests


### PR DESCRIPTION
Prevents use of extended native objects.