### PR TITLE
Shareable configs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,7 @@ var cli = meow({
 		'  --space         Use space indent instead of tabs  [Default: 2]',
 		'  --no-semicolon  Prevent use of semicolons',
 		'  --plugin        Include third-party plugins  [Can be set multiple times]',
+		'  --extend        Extend defaults with a custom config  [Can be set multiple times]',
 		'',
 		'Examples',
 		'  $ xo',

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var objectAssign = require('object-assign');
 var arrify = require('arrify');
 var pkgConf = require('pkg-conf');
 var deepAssign = require('deep-assign');
+var resolveFrom = require('resolve-from');
 
 var DEFAULT_IGNORE = [
 	'node_modules/**',
@@ -38,7 +39,9 @@ function handleOpts(opts) {
 	opts.ignores = opts.ignores || opts.ignore;
 	opts.plugins = opts.plugins || opts.plugin;
 	opts.rules = opts.rules || opts.rule;
+	opts.extends = opts.extends || opts.extend;
 
+	opts.extends = arrify(opts.extends);
 	opts.ignores = DEFAULT_IGNORE.concat(opts.ignores || []);
 
 	opts._config = deepAssign({}, DEFAULT_CONFIG, {
@@ -64,6 +67,21 @@ function handleOpts(opts) {
 
 	if (opts.esnext) {
 		opts._config.baseConfig = 'xo/esnext';
+	}
+
+	if (opts.extends.length > 0) {
+		// user's configs must be resolved to their absolute paths
+		var configs = opts.extends.map(function (name) {
+			if (name.indexOf('eslint-config-') === -1) {
+				name = 'eslint-config-' + name;
+			}
+
+			return resolveFrom(process.cwd(), name);
+		});
+
+		configs.unshift('xo');
+
+		opts._config.baseConfig.extends = configs;
 	}
 
 	opts._config.plugins.push('no-use-extend-native');

--- a/package.json
+++ b/package.json
@@ -63,11 +63,13 @@
     "meow": "^3.3.0",
     "object-assign": "^4.0.1",
     "pkg-conf": "^1.0.1",
+    "resolve-from": "^1.0.1",
     "update-notifier": "^0.5.0",
     "xo-init": "^0.3.0"
   },
   "devDependencies": {
     "ava": "*",
+    "eslint-config-xo-react": "^0.3.0",
     "eslint-plugin-react": "^3.5.1",
     "xo": "sindresorhus/xo#v0.9.0"
   }

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ $ xo --help
     --space         Use space indent instead of tabs  [Default: 2]
     --no-semicolon  Prevent use of semicolons
     --plugin        Include third-party plugins  [Can be set multiple times]
+    --extend        Extend defaults with a custom config  [Can be set multiple times]
 
   Examples
     $ xo
@@ -187,6 +188,12 @@ Set it to `false` to enforce no-semicolon style.
 Type: `array`
 
 Include third-party [plugins](http://eslint.org/docs/user-guide/configuring.html#configuring-plugins).
+
+### extends
+
+Type: `array`, `string`
+
+Use one or more [shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html) to override any of the default rules (like `rules` above).
 
 
 ## FAQ

--- a/test.js
+++ b/test.js
@@ -36,4 +36,13 @@ test('.lintText() - prevent use of extended native objects', t => {
 	t.end();
 });
 
+test('.lintText() - extends support', t => {
+	const results = fn.lintText('var React;\nReact.render(<App/>);\n', {
+		extends: 'xo-react'
+	}).results;
+	t.is(results[0].messages[0].ruleId, 'react/jsx-no-undef');
+	t.is(results[0].messages[0].message, '\'App\' is not defined.');
+	t.end();
+});
+
 // TODO: more tests


### PR DESCRIPTION
This PR allows a use of eslint's `extends` property to use [shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html).

Via CLI:

```
$ xo --extend sindre
$ xo --extend eslint-config-sindre
```

Via package.json:

```js
{
  "xo": {
    "extends": "sindre"
  }
}
```

Can also be an array of configs. If `eslint-config-` prefix is missing, it will be automatically added.