### PR TITLE
Bump no-use-extend-native to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-config-xo": "^0.7.0",
     "eslint-plugin-babel": "^2.1.1",
     "eslint-plugin-no-empty-blocks": "0.0.2",
-    "eslint-plugin-no-use-extend-native": "^0.1.5",
+    "eslint-plugin-no-use-extend-native": "^0.3.1",
     "get-stdin": "^5.0.0",
     "globby": "^3.0.0",
     "home-or-tmp": "^2.0.0",


### PR DESCRIPTION
I updated this plugin in a local version of XO and ran XO on AVA and Pageres without any issues/false positives. This plugin is also being used on all of my repos. *Hopefully*, there aren't any more false positives.

I didn't re-enable the plugin - figured that's up to the XO team.