### PR TITLE
Fixes the tests to use `test.cb` function.

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -5,25 +5,25 @@ function hasRule(results, ruleId) {
 	return results[0].messages.some(x => x.ruleId === ruleId);
 }
 
-test('.lintText()', t => {
+test.cb('.lintText()', t => {
 	const results = fn.lintText('\'use strict\';\nconsole.log("unicorn");\n').results;
 	t.true(hasRule(results, 'quotes'));
 	t.end();
 });
 
-test('.lintText() - `esnext` option', t => {
+test.cb('.lintText() - `esnext` option', t => {
 	const results = fn.lintText('function dec() {}\nconst x = {\n\t@dec()\n\ta: 1\n};\n', {esnext: true}).results;
 	t.true(hasRule(results, 'no-unused-vars'));
 	t.end();
 });
 
-test('.lintText() - JSX support', t => {
+test.cb('.lintText() - JSX support', t => {
 	const results = fn.lintText('var app = <div className="appClass">Hello, React!</div>;\n', {esnext: false}).results;
 	t.true(hasRule(results, 'no-unused-vars'));
 	t.end();
 });
 
-test('.lintText() - plugin support', t => {
+test.cb('.lintText() - plugin support', t => {
 	const results = fn.lintText('var React;\nReact.render(<App/>);\n', {
 		plugins: ['react'],
 		rules: {'react/jsx-no-undef': 2}
@@ -38,7 +38,7 @@ test('.lintText() - plugin support', t => {
 // 	t.end();
 // });
 
-test('.lintText() - extends support', t => {
+test.cb('.lintText() - extends support', t => {
 	const results = fn.lintText('var React;\nReact.render(<App/>);\n', {
 		extends: 'xo-react'
 	}).results;
@@ -46,7 +46,7 @@ test('.lintText() - extends support', t => {
 	t.end();
 });
 
-test('.lintText() - extends support with `esnext` option', t => {
+test.cb('.lintText() - extends support with `esnext` option', t => {
 	const results = fn.lintText('import path from \'path\';\nvar React;\nReact.render(<App/>);\n', {
 		esnext: true,
 		extends: 'xo-react'


### PR DESCRIPTION
When trying to test locally I saw that the tests didn't run; updated them to use the `test.cb` asynchronous pattern.