### PR TITLE
Open files with issues in an editor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ $ xo --help
     --no-semicolon  Prevent use of semicolons
     --plugin        Include third-party plugins  [Can be set multiple times]
     --extend        Extend defaults with a custom config  [Can be set multiple times]
+    --open          Open files with issues in your editor
 
   Examples
     $ xo


### PR DESCRIPTION
This PR fixes #38.

When `xo` is invoked with `--open` option, it automatically opens files with issues in a user's preferred editor (by checking `$EDITOR` environment variable):

```bash
$ xo --open
```

If `$EDITOR` is empty:

<img width="624" alt="screen shot 2015-12-13 at 9 45 26 am" src="https://cloud.githubusercontent.com/assets/697676/11766229/4bb69f5c-a17e-11e5-99d3-194923bba145.png">
