### PR TITLE
Don't destroy plugins.

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function handleOpts(opts) {
 		// always use the Babel parser so it won't throw
 		// on esnext features in normal mode
 		opts._config.parser = 'babel-eslint';
-		opts._config.plugins = ['babel'];
+		opts._config.plugins = ['babel'].concat(opts._config.plugins);
 		opts._config.rules['generator-star-spacing'] = 0;
 		opts._config.rules['arrow-parens'] = 0;
 		opts._config.rules['object-curly-spacing'] = 0;


### PR DESCRIPTION
If the `esnext` option is `false`, we currently blow away existing
plugins, replacing it with only the `babel` plugin. This prepends it.

This does not come with a test, as option handling is currently pretty difficult.
We can add the appropriate test for this there.

Reference:
  https://github.com/sindresorhus/xo/pull/58#discussion_r47583285