### PR TITLE
Merge custom rules after defaults are determined

### DIFF
--- a/options-manager.js
+++ b/options-manager.js
@@ -71,13 +71,9 @@ function buildConfig(opts) {
 		envs: opts.envs,
 		globals: opts.globals,
 		plugins: DEFAULT_PLUGINS.concat(opts.plugins || []),
-		rules: opts.rules,
+		rules: {},
 		fix: opts.fix
 	});
-
-	if (!config.rules) {
-		config.rules = {};
-	}
 
 	if (opts.space) {
 		var spaces = typeof opts.space === 'number' ? opts.space : 2;
@@ -100,6 +96,10 @@ function buildConfig(opts) {
 		config.rules['arrow-parens'] = 0;
 		config.rules['object-curly-spacing'] = 0;
 		config.rules['babel/object-curly-spacing'] = [2, 'never'];
+	}
+
+	if (opts.rules) {
+		objectAssign(config.rules, opts.rules);
 	}
 
 	if (opts.extends && opts.extends.length > 0) {

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -143,6 +143,29 @@ test('buildConfig: semicolon', t => {
 	});
 });
 
+test('buildConfig: rules', t => {
+	const config = manager.buildConfig({
+		rules: {
+			'babel/object-curly-spacing': [2, 'always']
+		}
+	});
+	delete config.cacheLocation;
+
+	t.same(config, {
+		useEslintrc: false,
+		cache: true,
+		baseConfig: {extends: 'xo'},
+		plugins: ['babel', 'no-empty-blocks', 'no-use-extend-native'],
+		rules: {
+			'generator-star-spacing': 0,
+			'arrow-parens': 0,
+			'object-curly-spacing': 0,
+			'babel/object-curly-spacing': [2, 'always']
+		},
+		parser: 'babel-eslint'
+	});
+});
+
 test('buildConfig: extends is resolved to cwd', t => {
 	const config = manager.buildConfig({
 		extends: ['foo']


### PR DESCRIPTION
Custom rules like 
```js
"babel/object-curly-spacing": [2, "always"]
```
are no longer ignored, as they are merged after defaults are determined.