### PR TITLE
Add eslint-plugin-import-order to plugins

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -2,10 +2,12 @@
 module.exports = {
 	plugins: [
 		'no-empty-blocks',
-		'no-use-extend-native'
+		'no-use-extend-native',
+		'import-order'
 	],
 	rules: {
 		'no-empty-blocks/no-empty-blocks': [2, 'allowCatch'],
-		'no-use-extend-native/no-use-extend-native': 2
+		'no-use-extend-native/no-use-extend-native': 2,
+		'import-order/import-order': 2
 	}
 };

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint": "^2.3.0",
     "eslint-config-xo": "^0.12.0",
     "eslint-plugin-babel": "^3.1.0",
+    "eslint-plugin-import-order": "^2.0.0",
     "eslint-plugin-no-empty-blocks": "0.0.2",
     "eslint-plugin-no-use-extend-native": "^0.3.2",
     "estraverse-fb": "^1.3.1",


### PR DESCRIPTION
As [per request](https://github.com/sindresorhus/module-requests/issues/62#issuecomment-201326964), this adds eslint-plugin-import-order to the list of plugins.

Let me know if and where I need to add tests, as I could not find related ones.