### PR TITLE
Make `--spaces` apply to JSX (i.e., override `eslint-config-xo-react`).

### DIFF
--- a/options-manager.js
+++ b/options-manager.js
@@ -84,6 +84,8 @@ function buildConfig(opts) {
 	if (opts.space) {
 		var spaces = typeof opts.space === 'number' ? opts.space : 2;
 		config.rules.indent = [2, spaces, {SwitchCase: 1}];
+		config.rules['react/jsx-indent-props'] = [2, spaces];
+		config.rules['react/jsx-indent'] = [2, spaces];
 	}
 
 	if (opts.semicolon === false) {


### PR DESCRIPTION
Hello @sindresorhus,

I have to work on this JSX project that insists on 4 space tabs, but discovered that `xo`'s `--space` flag wasn't overriding the JSX indentation set by `eslint-config-xo-react`.

This PR overrides the JSX spacing rules when the `--space` flag is used.

Thanks!

