### PR TITLE
add reference to emacs package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -265,6 +265,7 @@ XO is based on ESLint. This project started out as just a shareable ESLint confi
 - [Atom](https://github.com/sindresorhus/atom-linter-xo)
 - [TextMate 2](https://github.com/claylo/XO.tmbundle)
 - [VSCode](https://github.com/SamVerschueren/vscode-linter-xo)
+- [Emacs](https://github.com/j-em/xo-emacs)
 
 #### Vim
 


### PR DESCRIPTION
Hello.
I made an emacs package that provide some level of integration between xo and emacs.
It has been accepted and published to [MELPA](https://melpa.org/) which is a well-known emacs package repository.
I figured it would be a good idea to reference it over here too. :)

Let me know if there's anything you wanna know.