### PR TITLE
add `eslint-plugin-import`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-/* eslint-disable import-order/import-order */
+/* eslint-disable import/order */
 'use strict';
-
 var debug = require('debug')('xo');
 
 // Prefer the local installation of XO.
 var resolveCwd = require('resolve-cwd');
 var hasFlag = require('has-flag');
+
 var localCLI = resolveCwd('xo/cli');
 
 if (!hasFlag('no-local') && localCLI && localCLI !== __filename) {
@@ -15,11 +15,11 @@ if (!hasFlag('no-local') && localCLI && localCLI !== __filename) {
 	return;
 }
 
+var path = require('path');
+var spawn = require('child_process').spawn;
 var updateNotifier = require('update-notifier');
 var getStdin = require('get-stdin');
-var spawn = require('child_process').spawn;
 var meow = require('meow');
-var path = require('path');
 var formatterPretty = require('eslint-formatter-pretty');
 var xo = require('./');
 

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -2,18 +2,42 @@
 module.exports = {
 	plugins: [
 		'no-use-extend-native',
-		'import-order',
 		'ava',
 		'xo',
-		'promise'
+		'promise',
+		'import'
 	],
 	extends: [
 		'plugin:ava/recommended',
 		'plugin:xo/recommended'
 	],
+	settings: {
+		'import/extensions': ['.js'] // TODO: remove this when eslint-plugin-import@2 is out
+	},
 	rules: {
 		'no-use-extend-native/no-use-extend-native': 2,
-		'import-order/import-order': 2,
-		'promise/param-names': 2
+		'promise/param-names': 2,
+		// disabled because of https://github.com/benmosher/eslint-plugin-import/issues/268
+		// 'import/default': 2,
+		'import/export': 2,
+		// disabled because of https://github.com/benmosher/eslint-plugin-import/issues/378
+		// 'import/extensions': [2, 'never'],
+		'import/imports-first': 2,
+		// disabled because of https://github.com/benmosher/eslint-plugin-import/issues/268
+		// 'import/named': 2,
+		'import/namespace': 2,
+		'import/newline-after-import': 2,
+		'import/no-amd': 2,
+		// enable this sometime in the future when Node.js has ES2015 module support
+		// 'import/no-commonjs': 2,
+		// looks useful, but too unstable at the moment
+		// 'import/no-deprecated': 2,
+		'import/no-extraneous-dependencies': 2,
+		'import/no-mutable-exports': 2,
+		'import/no-named-as-default-member': 2,
+		'import/no-named-as-default': 2,
+		// disabled because of https://github.com/benmosher/eslint-plugin-import/issues/275
+		// 'import/no-unresolved': [2, {commonjs: true}],
+		'import/order': 2
 	}
 };

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-formatter-pretty": "^0.2.1",
     "eslint-plugin-ava": "^2.0.0",
     "eslint-plugin-babel": "^3.1.0",
-    "eslint-plugin-import-order": "^2.0.0",
+    "eslint-plugin-import": "^1.7.0",
     "eslint-plugin-no-use-extend-native": "^0.3.2",
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-xo": "^0.5.0",

--- a/test/fixtures/overrides/package.json
+++ b/test/fixtures/overrides/package.json
@@ -12,6 +12,9 @@
         "files": "test/foo.js",
         "space": 4
       }
-    ]
+    ],
+    "rules": {
+      "import/no-extraneous-dependencies": 0
+    }
   }
 }


### PR DESCRIPTION
https://github.com/benmosher/eslint-plugin-import (@benmosher fyi)

-

@jamestalmage @novemberborn @vdemedes @kevva @SamVerschueren @jfmengels  and anyone looking. I could use some help with testing this. Git checkout out this PR locally, `npm link` it globally, and run `xo --no-local` on your projects to see if there are any problems (not lint violation, unless it's wrong).

-

Known issues:

- [x] Don't try to read imported JSON files: https://github.com/benmosher/eslint-plugin-import/issues/267
- [x] Support optionalDependencies in the `no-extraneous-dependencies` rule: https://github.com/benmosher/eslint-plugin-import/issues/266
- [x] The `newline-after-import` rule requires newline after every import: https://github.com/benmosher/eslint-plugin-import/issues/318
- [ ] Ignore CommonJS exports in the `named` rule: https://github.com/benmosher/eslint-plugin-import/issues/268
- [ ] Add ability to ignore certain packages from all rules: https://github.com/benmosher/eslint-plugin-import/issues/275
- [ ] Lodash modularized libs cause false positive for `import/extensions` https://github.com/benmosher/eslint-plugin-import/issues/378

*(Help welcome for those)*