### PR TITLE
Give stdout time to flush.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -83,7 +83,11 @@ function log(report) {
 	var reporter = opts.reporter ? xo.getFormatter(opts.reporter) : formatterPretty;
 
 	process.stdout.write(reporter(report.results));
-	process.exit(report.errorCount === 0 ? 0 : 1);
+
+	setTimeout(function () {
+		// give stdout time to flush.
+		process.exit(report.errorCount === 0 ? 0 : 1);
+	}, 100);
 }
 
 function open(report) {

--- a/cli.js
+++ b/cli.js
@@ -22,6 +22,7 @@ var meow = require('meow');
 var path = require('path');
 var formatterPretty = require('eslint-formatter-pretty');
 var xo = require('./');
+var exit = require('exit');
 
 var cli = meow({
 	help: [
@@ -84,10 +85,7 @@ function log(report) {
 
 	process.stdout.write(reporter(report.results));
 
-	setTimeout(function () {
-		// give stdout time to flush.
-		process.exit(report.errorCount === 0 ? 0 : 1);
-	}, 100);
+	exit(report.errorCount === 0 ? 0 : 1);
 }
 
 function open(report) {
@@ -161,12 +159,14 @@ if (opts.init) {
 	getStdin().then(function (str) {
 		if (opts.fix) {
 			console.error('The `fix` option is not supported on stdin');
-			process.exit(1);
+			exit(1);
+			return;
 		}
 
 		if (opts.open) {
 			console.error('The `open` option is not supported on stdin');
-			process.exit(1);
+			exit(1);
+			return;
 		}
 
 		log(xo.lintText(str, opts));

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-no-use-extend-native": "^0.3.2",
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-xo": "^0.3.1",
+    "exit": "^0.1.2",
     "get-stdin": "^5.0.0",
     "globby": "^4.0.0",
     "has-flag": "^2.0.0",


### PR DESCRIPTION

I do not know why, but I'm suddenly seeing the process exit before the entire report prints.

This fixes the problem. I really wish there was a better way. This just feels wrong.

What I was seeing:

<img width="492" alt="screenshot 2016-05-05 21 11 05" src="https://cloud.githubusercontent.com/assets/4082216/15062034/114baada-130a-11e6-82b7-0a6fe4d303b6.png">