### PR TITLE
Add `extensions` option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -42,7 +42,7 @@ const cli = meow(`
 	  --extend        Extend defaults with a custom config  [Can be set multiple times]
 	  --open          Open files with issues in your editor
 	  --quiet         Show only errors and no warnings
-	  --extension     Additional extensions to lint [Can be set multiple times]
+	  --extension     Additional extension to lint [Can be set multiple times]
 
 	Examples
 	  $ xo

--- a/cli.js
+++ b/cli.js
@@ -28,20 +28,21 @@ const cli = meow(`
 	  $ xo [<file|glob> ...]
 
 	Options
-	  --init          Add XO to your project
-	  --fix           Automagically fix issues
-	  --reporter      Reporter to use
-	  --stdin         Validate code from stdin
-	  --esnext        Enforce ES2015+ rules
-	  --env           Environment preset  [Can be set multiple times]
-	  --global        Global variable  [Can be set multiple times]
-	  --ignore        Additional paths to ignore  [Can be set multiple times]
-	  --space         Use space indent instead of tabs  [Default: 2]
-	  --no-semicolon  Prevent use of semicolons
-	  --plugin        Include third-party plugins  [Can be set multiple times]
-	  --extend        Extend defaults with a custom config  [Can be set multiple times]
-	  --open          Open files with issues in your editor
-	  --quiet         Show only errors and no warnings
+	  --init           Add XO to your project
+	  --fix            Automagically fix issues
+	  --reporter       Reporter to use
+	  --stdin          Validate code from stdin
+	  --esnext         Enforce ES2015+ rules
+	  --env            Environment preset  [Can be set multiple times]
+	  --global         Global variable  [Can be set multiple times]
+	  --ignore         Additional paths to ignore  [Can be set multiple times]
+	  --space          Use space indent instead of tabs  [Default: 2]
+	  --no-semicolon   Prevent use of semicolons
+	  --plugin         Include third-party plugins  [Can be set multiple times]
+	  --extend         Extend defaults with a custom config  [Can be set multiple times]
+	  --open           Open files with issues in your editor
+	  --quiet          Show only errors and no warnings
+	  --any-extension  Allow files of any extension to be linted
 
 	Examples
 	  $ xo
@@ -63,7 +64,8 @@ const cli = meow(`
 		'compact',
 		'stdin',
 		'fix',
-		'open'
+		'open',
+		'any-extension'
 	]
 });
 

--- a/cli.js
+++ b/cli.js
@@ -28,21 +28,20 @@ const cli = meow(`
 	  $ xo [<file|glob> ...]
 
 	Options
-	  --init           Add XO to your project
-	  --fix            Automagically fix issues
-	  --reporter       Reporter to use
-	  --stdin          Validate code from stdin
-	  --esnext         Enforce ES2015+ rules
-	  --env            Environment preset  [Can be set multiple times]
-	  --global         Global variable  [Can be set multiple times]
-	  --ignore         Additional paths to ignore  [Can be set multiple times]
-	  --space          Use space indent instead of tabs  [Default: 2]
-	  --no-semicolon   Prevent use of semicolons
-	  --plugin         Include third-party plugins  [Can be set multiple times]
-	  --extend         Extend defaults with a custom config  [Can be set multiple times]
-	  --open           Open files with issues in your editor
-	  --quiet          Show only errors and no warnings
-	  --any-extension  Allow files of any extension to be linted
+	  --init          Add XO to your project
+	  --fix           Automagically fix issues
+	  --reporter      Reporter to use
+	  --stdin         Validate code from stdin
+	  --esnext        Enforce ES2015+ rules
+	  --env           Environment preset  [Can be set multiple times]
+	  --global        Global variable  [Can be set multiple times]
+	  --ignore        Additional paths to ignore  [Can be set multiple times]
+	  --space         Use space indent instead of tabs  [Default: 2]
+	  --no-semicolon  Prevent use of semicolons
+	  --plugin        Include third-party plugins  [Can be set multiple times]
+	  --extend        Extend defaults with a custom config  [Can be set multiple times]
+	  --open          Open files with issues in your editor
+	  --quiet         Show only errors and no warnings
 
 	Examples
 	  $ xo
@@ -64,8 +63,7 @@ const cli = meow(`
 		'compact',
 		'stdin',
 		'fix',
-		'open',
-		'any-extension'
+		'open'
 	]
 });
 

--- a/cli.js
+++ b/cli.js
@@ -42,6 +42,7 @@ const cli = meow(`
 	  --extend        Extend defaults with a custom config  [Can be set multiple times]
 	  --open          Open files with issues in your editor
 	  --quiet         Show only errors and no warnings
+	  --extension     Additional extensions to lint [Can be set multiple times]
 
 	Examples
 	  $ xo
@@ -51,6 +52,7 @@ const cli = meow(`
 	  $ xo --env=node --env=mocha
 	  $ xo --init --esnext
 	  $ xo --plugin=react
+	  $ xo --plugin=html --extension=html
 
 	Tips
 	  Put options in package.json instead of using flags so other tools can read it.

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ exports.lintFiles = (patterns, opts) => {
 	opts = optionsManager.preprocess(opts);
 
 	if (patterns.length === 0) {
-		patterns = '**/*.{js,jsx}';
+		patterns = '**/*';
 	}
 
 	return globby(patterns, {ignore: opts.ignores}).then(paths => {

--- a/index.js
+++ b/index.js
@@ -33,10 +33,12 @@ exports.lintFiles = (patterns, opts) => {
 
 	return globby(patterns, {ignore: opts.ignores}).then(paths => {
 		// when users are silly and don't specify an extension in the glob pattern
-		paths = paths.filter(x => {
-			const ext = path.extname(x);
-			return ext === '.js' || ext === '.jsx';
-		});
+		if (!opts.anyExtension) {
+			paths = paths.filter(x => {
+				const ext = path.extname(x);
+				return ext === '.js' || ext === '.jsx';
+			});
+		}
 
 		if (!(opts.overrides && opts.overrides.length > 0)) {
 			return runEslint(paths, opts);

--- a/index.js
+++ b/index.js
@@ -33,12 +33,10 @@ exports.lintFiles = (patterns, opts) => {
 
 	return globby(patterns, {ignore: opts.ignores}).then(paths => {
 		// when users are silly and don't specify an extension in the glob pattern
-		if (!opts.anyExtension) {
-			paths = paths.filter(x => {
-				const ext = path.extname(x);
-				return ext === '.js' || ext === '.jsx';
-			});
-		}
+		paths = paths.filter(x => {
+			const ext = path.extname(x);
+			return ext === '.js' || ext === '.jsx';
+		});
 
 		if (!(opts.overrides && opts.overrides.length > 0)) {
 			return runEslint(paths, opts);

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ exports.lintFiles = (patterns, opts) => {
 		paths = paths.filter(x => {
 			// Remove dot before the actual extension
 			const ext = path.extname(x).replace('.', '');
-			return opts.extensions.indexOf(ext) > -1;
+			return opts.extensions.indexOf(ext) !== -1;
 		});
 
 		if (!(opts.overrides && opts.overrides.length > 0)) {

--- a/index.js
+++ b/index.js
@@ -32,10 +32,12 @@ exports.lintFiles = (patterns, opts) => {
 	}
 
 	return globby(patterns, {ignore: opts.ignores}).then(paths => {
-		// when users are silly and don't specify an extension in the glob pattern
+		// filter out unwanted file extensions
+		// for silly users that don't specify an extension in the glob pattern
 		paths = paths.filter(x => {
-			const ext = path.extname(x);
-			return ext === '.js' || ext === '.jsx';
+			// Remove dot before the actual extension
+			const ext = path.extname(x).replace('.', '');
+			return opts.extensions.indexOf(ext) > -1;
 		});
 
 		if (!(opts.overrides && opts.overrides.length > 0)) {

--- a/options-manager.js
+++ b/options-manager.js
@@ -22,6 +22,11 @@ const DEFAULT_IGNORE = [
 	'dist/**'
 ];
 
+const DEFAULT_EXTENSION = [
+	'js',
+	'jsx'
+];
+
 const DEFAULT_CONFIG = {
 	useEslintrc: false,
 	cache: true,
@@ -45,7 +50,8 @@ function normalizeOpts(opts) {
 		'ignore',
 		'plugin',
 		'rule',
-		'extend'
+		'extend',
+		'extension'
 	].forEach(singular => {
 		const plural = singular + 's';
 		let value = opts[plural] || opts[singular];
@@ -195,6 +201,7 @@ function preprocess(opts) {
 	opts = mergeWithPkgConf(opts);
 	opts = normalizeOpts(opts);
 	opts.ignores = DEFAULT_IGNORE.concat(opts.ignores || []);
+	opts.extensions = DEFAULT_EXTENSION.concat(opts.extensions || []);
 	return opts;
 }
 

--- a/readme.md
+++ b/readme.md
@@ -35,21 +35,20 @@ $ xo --help
     $ xo [<file|glob> ...]
 
   Options
-    --init           Add XO to your project
-    --fix            Automagically fix issues
-    --reporter       Reporter to use
-    --stdin          Validate code from stdin
-    --esnext         Enforce ES2015+ rules
-    --env            Environment preset  [Can be set multiple times]
-    --global         Global variable  [Can be set multiple times]
-    --ignore         Additional paths to ignore  [Can be set multiple times]
-    --space          Use space indent instead of tabs  [Default: 2]
-    --no-semicolon   Prevent use of semicolons
-    --plugin         Include third-party plugins  [Can be set multiple times]
-    --extend         Extend defaults with a custom config  [Can be set multiple times]
-    --open           Open files with issues in your editor
-    --quiet          Show only errors and no warnings
-    --any-extension  Allow files of any extension to be linted
+    --init          Add XO to your project
+    --fix           Automagically fix issues
+    --reporter      Reporter to use
+    --stdin         Validate code from stdin
+    --esnext        Enforce ES2015+ rules
+    --env           Environment preset  [Can be set multiple times]
+    --global        Global variable  [Can be set multiple times]
+    --ignore        Additional paths to ignore  [Can be set multiple times]
+    --space         Use space indent instead of tabs  [Default: 2]
+    --no-semicolon  Prevent use of semicolons
+    --plugin        Include third-party plugins  [Can be set multiple times]
+    --extend        Extend defaults with a custom config  [Can be set multiple times]
+    --open          Open files with issues in your editor
+    --quiet         Show only errors and no warnings
 
   Examples
     $ xo
@@ -197,13 +196,6 @@ Include third-party [plugins](http://eslint.org/docs/user-guide/configuring.html
 Type: `Array`, `string`
 
 Use one or more [shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html) to override any of the default rules (like `rules` above).
-
-### anyExtension
-
-Type: `boolean`<br>
-Default: `false` *(only .js and .jsx may be linted)*
-
-Set it to `true` to allow xo to lint any file extension.
 
 
 ## Config Overrides

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ $ xo --help
     --extend        Extend defaults with a custom config  [Can be set multiple times]
     --open          Open files with issues in your editor
     --quiet         Show only errors and no warnings
+    --extension     Additional extensions to lint [Can be set multiple times]
 
   Examples
     $ xo
@@ -58,6 +59,7 @@ $ xo --help
     $ xo --env=node --env=mocha
     $ xo --init --esnext
     $ xo --plugin=react
+    $ xo --plugin=html --extension=html
 
   Tips
     Put options in package.json instead of using flags so other tools can read it.
@@ -196,6 +198,12 @@ Include third-party [plugins](http://eslint.org/docs/user-guide/configuring.html
 Type: `Array`, `string`
 
 Use one or more [shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html) to override any of the default rules (like `rules` above).
+
+### extensions
+
+Type: `Array`, `string`
+
+Allow more extensions to be linted besides `.js` and `.jsx`. Make sure they're supported by ESLint or an ESLint plugin.
 
 
 ## Config Overrides

--- a/readme.md
+++ b/readme.md
@@ -35,20 +35,21 @@ $ xo --help
     $ xo [<file|glob> ...]
 
   Options
-    --init          Add XO to your project
-    --fix           Automagically fix issues
-    --reporter      Reporter to use
-    --stdin         Validate code from stdin
-    --esnext        Enforce ES2015+ rules
-    --env           Environment preset  [Can be set multiple times]
-    --global        Global variable  [Can be set multiple times]
-    --ignore        Additional paths to ignore  [Can be set multiple times]
-    --space         Use space indent instead of tabs  [Default: 2]
-    --no-semicolon  Prevent use of semicolons
-    --plugin        Include third-party plugins  [Can be set multiple times]
-    --extend        Extend defaults with a custom config  [Can be set multiple times]
-    --open          Open files with issues in your editor
-    --quiet         Show only errors and no warnings
+    --init           Add XO to your project
+    --fix            Automagically fix issues
+    --reporter       Reporter to use
+    --stdin          Validate code from stdin
+    --esnext         Enforce ES2015+ rules
+    --env            Environment preset  [Can be set multiple times]
+    --global         Global variable  [Can be set multiple times]
+    --ignore         Additional paths to ignore  [Can be set multiple times]
+    --space          Use space indent instead of tabs  [Default: 2]
+    --no-semicolon   Prevent use of semicolons
+    --plugin         Include third-party plugins  [Can be set multiple times]
+    --extend         Extend defaults with a custom config  [Can be set multiple times]
+    --open           Open files with issues in your editor
+    --quiet          Show only errors and no warnings
+    --any-extension  Allow files of any extension to be linted
 
   Examples
     $ xo
@@ -196,6 +197,13 @@ Include third-party [plugins](http://eslint.org/docs/user-guide/configuring.html
 Type: `Array`, `string`
 
 Use one or more [shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html) to override any of the default rules (like `rules` above).
+
+### anyExtension
+
+Type: `boolean`<br>
+Default: `false` *(only .js and .jsx may be linted)*
+
+Set it to `true` to allow xo to lint any file extension.
 
 
 ## Config Overrides

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ $ xo --help
     --extend        Extend defaults with a custom config  [Can be set multiple times]
     --open          Open files with issues in your editor
     --quiet         Show only errors and no warnings
-    --extension     Additional extensions to lint [Can be set multiple times]
+    --extension     Additional extension to lint [Can be set multiple times]
 
   Examples
     $ xo
@@ -201,7 +201,7 @@ Use one or more [shareable configs](http://eslint.org/docs/developer-guide/share
 
 ### extensions
 
-Type: `Array`, `string`
+Type: `Array`
 
 Allow more extensions to be linted besides `.js` and `.jsx`. Make sure they're supported by ESLint or an ESLint plugin.
 

--- a/test/api.js
+++ b/test/api.js
@@ -77,3 +77,16 @@ test('lintText() - overrides support', async t => {
 	const indexResults = fn.lintText(await readFile(bar, 'utf8'), {filename: index, cwd}).results;
 	t.is(indexResults[0].errorCount, 0, indexResults[0]);
 });
+
+test('.lintFiles() - only accepts whitelisted extensions', async t => {
+	// Markdown files will always produce linter errors and will not be going away
+	const mdGlob = path.join(__dirname, '..', '*.md');
+
+	// No files should be linted = no errors
+	const noOptionsResults = await fn.lintFiles(mdGlob, {});
+	t.is(noOptionsResults.errorCount, 0);
+
+	// Markdown files linted (with no plugin for it) = errors
+	const moreExtensionsResults = await fn.lintFiles(mdGlob, {extensions: ['md']});
+	t.true(moreExtensionsResults.errorCount > 0);
+});

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -12,7 +12,8 @@ test('normalizeOpts: makes all the opts plural and arrays', t => {
 		ignore: 'test.js',
 		plugin: 'my-plugin',
 		rule: {'my-rule': 'foo'},
-		extend: 'foo'
+		extend: 'foo',
+		extension: 'html'
 	});
 
 	t.deepEqual(opts, {
@@ -21,7 +22,8 @@ test('normalizeOpts: makes all the opts plural and arrays', t => {
 		ignores: ['test.js'],
 		plugins: ['my-plugin'],
 		rules: {'my-rule': 'foo'},
-		extends: ['foo']
+		extends: ['foo'],
+		extensions: ['html']
 	});
 });
 


### PR DESCRIPTION
Solves #117 (Allowing more file extensions)

Trying to detect whether the glob pattern restricts file extensions quickly gets out of hand. There are arrays of patterns, there can be negations, obscure regex syntax that may not be accounted for and that does limit what extensions can be used...

So, I added a new option: anyExtension (or --any-extension).
Set it to true, and the extension filter is disabled.

In my opinion, it would be better to just remove it altogether. Most people are probably just using the default expression and the ignores option, so impact should be minimal. A FAQ entry would be fine. Maybe this should happen for 1.0?