### PR TITLE
Support plugin config in the `extends` option

### DIFF
--- a/options-manager.js
+++ b/options-manager.js
@@ -145,6 +145,11 @@ function buildConfig(opts) {
 				return name;
 			}
 
+			// don't do anything if it's a config from a plugin
+			if (name.indexOf('plugin:') === 0) {
+				return name;
+			}
+
 			if (!name.includes('eslint-config-')) {
 				name = `eslint-config-${name}`;
 			}

--- a/options-manager.js
+++ b/options-manager.js
@@ -146,7 +146,7 @@ function buildConfig(opts) {
 			}
 
 			// don't do anything if it's a config from a plugin
-			if (name.indexOf('plugin:') === 0) {
+			if (name.startsWith('plugin:')) {
 				return name;
 			}
 

--- a/readme.md
+++ b/readme.md
@@ -212,7 +212,7 @@ Include third-party [plugins](http://eslint.org/docs/user-guide/configuring.html
 
 Type: `Array`, `string`
 
-Use one or more [shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html) to override any of the default rules (like `rules` above).
+Use one or more [shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html) or [plugin configs](http://eslint.org/docs/user-guide/configuring#using-the-configuration-from-a-plugin) to override any of the default rules (like `rules` above).
 
 ### extensions
 

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -88,6 +88,14 @@ test('buildConfig: settings', t => {
 	t.deepEqual(config.baseConfig.settings, settings);
 });
 
+test('buildConfig: extends', t => {
+	const extendsOption = ['plugin:foo/bar', 'eslint-config-foo-bar', 'foo-bar-two'];
+	const config = manager.buildConfig({extends: extendsOption});
+	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 3], 'plugin:foo/bar');
+	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 2], 'cwd/eslint-config-foo-bar');
+	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 1], 'cwd/eslint-config-foo-bar-two');
+});
+
 test('findApplicableOverrides', t => {
 	const result = manager.findApplicableOverrides('/user/dir/foo.js', [
 		{files: '**/f*.js'},

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -91,9 +91,10 @@ test('buildConfig: settings', t => {
 test('buildConfig: extends', t => {
 	const extendsOption = ['plugin:foo/bar', 'eslint-config-foo-bar', 'foo-bar-two'];
 	const config = manager.buildConfig({extends: extendsOption});
-	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 3], 'plugin:foo/bar');
-	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 2], 'cwd/eslint-config-foo-bar');
-	t.is(config.baseConfig.extends[config.baseConfig.extends.length - 1], 'cwd/eslint-config-foo-bar-two');
+	const extendsConfig = config.baseConfig.extends;
+	t.is(extendsConfig[extendsConfig.length - 3], 'plugin:foo/bar');
+	t.is(extendsConfig[extendsConfig.length - 2], 'cwd/eslint-config-foo-bar');
+	t.is(extendsConfig[extendsConfig.length - 1], 'cwd/eslint-config-foo-bar-two');
 });
 
 test('findApplicableOverrides', t => {

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -89,12 +89,18 @@ test('buildConfig: settings', t => {
 });
 
 test('buildConfig: extends', t => {
-	const extendsOption = ['plugin:foo/bar', 'eslint-config-foo-bar', 'foo-bar-two'];
+	const extendsOption = [
+		'plugin:foo/bar',
+		'eslint-config-foo-bar',
+		'foo-bar-two'
+	];
 	const config = manager.buildConfig({extends: extendsOption});
 	const extendsConfig = config.baseConfig.extends;
-	t.is(extendsConfig[extendsConfig.length - 3], 'plugin:foo/bar');
-	t.is(extendsConfig[extendsConfig.length - 2], 'cwd/eslint-config-foo-bar');
-	t.is(extendsConfig[extendsConfig.length - 1], 'cwd/eslint-config-foo-bar-two');
+	t.deepEqual(extendsConfig.slice(-3), [
+		'plugin:foo/bar',
+		'cwd/eslint-config-foo-bar',
+		'cwd/eslint-config-foo-bar-two'
+	]);
 });
 
 test('findApplicableOverrides', t => {


### PR DESCRIPTION
## Current issue
XO allows to specify sharable configs to override any of the default rules [link](https://github.com/sindresorhus/xo#extends). However, in ESLint it is allowed to use configs shared by plugins (prefixed with `eslint-plugin-`, next to shared configs (prefixed with `eslint-config-` and absolute/relative paths. These plugin configs are prefixed with `plugin:`, [see here](http://eslint.org/docs/user-guide/configuring#using-the-configuration-from-a-plugin).

## Contribution
This PR allows to specify such plugin configs in the XO configuration, by checking whether the name starts with `plugin:` and only prepending `eslint-config-` if that is not the case.