### PR TITLE
Make code on GitHub look better

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 indent_style = tab
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
@@ -9,4 +10,3 @@ insert_final_newline = true
 
 [{package.json,*.yml}]
 indent_style = space
-indent_size = 2


### PR DESCRIPTION
Feel free to reject this if there's some cool reason.

8-space tabs r gross. I'd prefer not to install _yet another_ Chrome extension just to browse code on GitHub.

Is there a cool reason specifying `[*] indent_size` is bad? Tell meeeee :D