### PR TITLE
feat: apply `.ignores` to `lintText`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 const path = require('path');
-const arrayEqual = require('array-equal');
 const eslint = require('eslint');
 const globby = require('globby');
+const isEqual = require('lodash.isequal');
 const multimatch = require('multimatch');
 const optionsManager = require('./options-manager');
 
@@ -22,8 +22,8 @@ exports.lintText = (str, opts) => {
 	opts = optionsManager.buildConfig(opts);
 	const defaultIgnores = optionsManager.getIgnores({}).ignores;
 
-	if (opts.ignores && !arrayEqual(defaultIgnores, opts.ignores) && typeof opts.filename !== 'string') {
-		throw new Error(`xo: opts.filename must be string when providing opts.ignores. Received value "${opts.filename}" of type "${typeof opts.filename}" for opts.filename.`);
+	if (opts.ignores && !isEqual(defaultIgnores, opts.ignores) && typeof opts.filename !== 'string') {
+		throw new Error('The `ignores` option requires the `filename` option to be defined.');
 	}
 
 	if (opts.ignores && opts.ignores.length > 0 && opts.filename) {

--- a/index.js
+++ b/index.js
@@ -2,16 +2,35 @@
 const path = require('path');
 const eslint = require('eslint');
 const globby = require('globby');
+const multimatch = require('multimatch');
 const optionsManager = require('./options-manager');
 
 exports.lintText = (str, opts) => {
 	opts = optionsManager.preprocess(opts);
+
+	if (opts.cwd && opts.filename) {
+		const filename = path.relative(opts.cwd, opts.filename);
+
+		if (multimatch([filename], opts.ignores)) {
+			return {
+				errorCount: 0,
+				warningCount: 0,
+				results: [{
+					errorCount: 0,
+					filePath: filename,
+					messages: [],
+					warningCount: 0
+				}]
+			};
+		}
+	}
 
 	if (opts.overrides && opts.overrides.length > 0) {
 		const overrides = opts.overrides;
 		delete opts.overrides;
 
 		const filename = path.relative(opts.cwd, opts.filename);
+
 		const foundOverrides = optionsManager.findApplicableOverrides(filename, overrides);
 		opts = optionsManager.mergeApplicableOverrides(opts, foundOverrides.applicable);
 	}

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "get-stdin": "^5.0.0",
     "globby": "^6.0.0",
     "has-flag": "^2.0.0",
+    "lodash.isequal": "^4.4.0",
     "meow": "^3.4.2",
     "multimatch": "^2.1.0",
     "parse-gitignore": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "simple"
   ],
   "dependencies": {
-    "array-equal": "^1.0.0",
     "arrify": "^1.0.0",
     "debug": "^2.2.0",
     "deep-assign": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "simple"
   ],
   "dependencies": {
+    "array-equal": "^1.0.0",
     "arrify": "^1.0.0",
     "debug": "^2.2.0",
     "deep-assign": "^1.0.0",

--- a/test/api.js
+++ b/test/api.js
@@ -61,12 +61,26 @@ test('.lintText() - respect overrides', t => {
 	t.is(result.warningCount, 0);
 });
 
+test('.lintText() - overriden ignore', t => {
+	const result = fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
+		filename: 'unignored.js',
+		overrides: [
+			{
+				files: ['unignored.js'],
+				ignores: ['unignored.js']
+			}
+		]
+	});
+	t.is(result.errorCount, 0);
+	t.is(result.warningCount, 0);
+});
+
 test('.lintText() - `ignores` option without filename', t => {
 	t.throws(() => {
 		fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
 			ignores: ['ignored/**/*.js']
 		});
-	}, /opts\.filename must be string when providing opts\.ignores/);
+	}, /The `ignores` option requires the `filename` option to be defined./);
 });
 
 test('.lintText() - JSX support', t => {

--- a/test/api.js
+++ b/test/api.js
@@ -20,9 +20,16 @@ test('.lintText() - `esnext` option', t => {
 	t.true(hasRule(results, 'no-var'));
 });
 
+test('.lintText() - default `ignores`', t => {
+	const result = fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
+		filename: 'node_modules/ignored/index.js'
+	});
+	t.is(result.errorCount, 0);
+	t.is(result.warningCount, 0);
+});
+
 test('.lintText() - `ignores` option', t => {
 	const result = fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
-		cwd: process.cwd(),
 		filename: 'ignored/index.js',
 		ignores: ['ignored/**/*.js']
 	});
@@ -39,12 +46,27 @@ test('.lintText() - `ignores` option without cwd', t => {
 	t.is(result.warningCount, 0);
 });
 
-test('.lintText() - `ignores` option without filename', t => {
+test('.lintText() - respect overrides', t => {
 	const result = fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
-		ignores: ['ignored/**/*.js']
+		filename: 'ignored/index.js',
+		ignores: ['ignored/**/*.js'],
+		overrides: [
+			{
+				files: ['ignored/**/*.js'],
+				ignores: []
+			}
+		]
 	});
 	t.is(result.errorCount, 1);
 	t.is(result.warningCount, 0);
+});
+
+test('.lintText() - `ignores` option without filename', t => {
+	t.throws(() => {
+		fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
+			ignores: ['ignored/**/*.js']
+		});
+	}, /opts\.filename must be string when providing opts\.ignores/);
 });
 
 test('.lintText() - JSX support', t => {

--- a/test/api.js
+++ b/test/api.js
@@ -20,6 +20,33 @@ test('.lintText() - `esnext` option', t => {
 	t.true(hasRule(results, 'no-var'));
 });
 
+test('.lintText() - `ignores` option', t => {
+	const result = fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
+		cwd: process.cwd(),
+		filename: 'ignored/index.js',
+		ignores: ['ignored/**/*.js']
+	});
+	t.is(result.errorCount, 0);
+	t.is(result.warningCount, 0);
+});
+
+test('.lintText() - `ignores` option without cwd', t => {
+	const result = fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
+		filename: 'ignored/index.js',
+		ignores: ['ignored/**/*.js']
+	});
+	t.is(result.errorCount, 0);
+	t.is(result.warningCount, 0);
+});
+
+test('.lintText() - `ignores` option without filename', t => {
+	const result = fn.lintText(`'use strict'\nconsole.log('unicorn');\n`, {
+		ignores: ['ignored/**/*.js']
+	});
+	t.is(result.errorCount, 1);
+	t.is(result.warningCount, 0);
+});
+
 test('.lintText() - JSX support', t => {
 	const results = fn.lintText('var app = <div className="appClass">Hello, React!</div>;\n', {esnext: false}).results;
 	t.true(hasRule(results, 'no-unused-vars'));


### PR DESCRIPTION
- add multimatch-powered short-circuit to `lintText`
- add supporting test cases
- throw for opts.ignores without opts.filename
-  use default ignores when opts.filename is given
- closes #168

BREAKING CHANGES:
* lintText now uses the same default ignores as lintFiles with opts.filename
  * **/node_modules/**
  * **/bower_components/**
  * coverage/**
  * {tmp,temp}/**
  * **/*.min.js
  * **/bundle.js
  * fixtures{-*,}.{js,jsx}
  * fixture{s,}/**
  * {test,tests,spec,__tests__}/fixture{s,}/**
  * vendor/**
  * dist/**
* lintText now throws when providing opts.ignores without opts.filename