### PR TITLE
Making default extenders optional

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -28,21 +28,22 @@ const cli = meow(`
 	  $ xo [<file|glob> ...]
 
 	Options
-	  --init          Add XO to your project
-	  --fix           Automagically fix issues
-	  --reporter      Reporter to use
-	  --stdin         Validate/fix code from stdin
-	  --env           Environment preset  [Can be set multiple times]
-	  --global        Global variable  [Can be set multiple times]
-	  --ignore        Additional paths to ignore  [Can be set multiple times]
-	  --space         Use space indent instead of tabs  [Default: 2]
-	  --no-semicolon  Prevent use of semicolons
-	  --plugin        Include third-party plugins  [Can be set multiple times]
-	  --extend        Extend defaults with a custom config  [Can be set multiple times]
-	  --open          Open files with issues in your editor
-	  --quiet         Show only errors and no warnings
-	  --extension     Additional extension to lint [Can be set multiple times]
-	  --no-esnext     Don't enforce ES2015+ rules
+	  --init                   Add XO to your project
+	  --fix                    Automagically fix issues
+	  --reporter               Reporter to use
+	  --stdin                  Validate/fix code from stdin
+	  --env                    Environment preset  [Can be set multiple times]
+	  --global                 Global variable  [Can be set multiple times]
+	  --ignore                 Additional paths to ignore  [Can be set multiple times]
+	  --space                  Use space indent instead of tabs  [Default: 2]
+	  --no-semicolon           Prevent use of semicolons
+	  --plugin                 Include third-party plugins  [Can be set multiple times]
+	  --skip-default-extenders Do not add the default extenders
+	  --extend                 Extend defaults with a custom config  [Can be set multiple times]
+	  --open                   Open files with issues in your editor
+	  --quiet                  Show only errors and no warnings
+	  --extension              Additional extension to lint [Can be set multiple times]
+	  --no-esnext              Don't enforce ES2015+ rules
 
 	Examples
 	  $ xo
@@ -66,7 +67,8 @@ const cli = meow(`
 		'compact',
 		'stdin',
 		'fix',
-		'open'
+		'open',
+		'skip-default-extenders'
 	]
 });
 

--- a/options-manager.js
+++ b/options-manager.js
@@ -29,16 +29,18 @@ const DEFAULT_EXTENSION = [
 	'jsx'
 ];
 
+const DEFAULT_EXTENDERS = [
+	'xo',
+	path.join(__dirname, 'config/overrides.js'),
+	path.join(__dirname, 'config/plugins.js')
+];
+
 const DEFAULT_CONFIG = {
 	useEslintrc: false,
 	cache: true,
 	cacheLocation: path.join(os.homedir() || os.tmpdir(), '.xo-cache/'),
 	baseConfig: {
-		extends: [
-			'xo',
-			path.join(__dirname, 'config/overrides.js'),
-			path.join(__dirname, 'config/plugins.js')
-		]
+		extends: []
 	}
 };
 
@@ -134,6 +136,10 @@ function buildConfig(opts) {
 
 	if (opts.parser) {
 		config.baseConfig.parser = opts.parser;
+	}
+
+	if (!opts.skipDefaultExtenders) {
+		config.baseConfig.extends = config.baseConfig.extends.concat(DEFAULT_EXTENDERS);
 	}
 
 	if (opts.extends && opts.extends.length > 0) {

--- a/readme.md
+++ b/readme.md
@@ -51,21 +51,22 @@ $ xo --help
     $ xo [<file|glob> ...]
 
   Options
-    --init          Add XO to your project
-    --fix           Automagically fix issues
-    --reporter      Reporter to use
-    --stdin         Validate/fix code from stdin
-    --env           Environment preset  [Can be set multiple times]
-    --global        Global variable  [Can be set multiple times]
-    --ignore        Additional paths to ignore  [Can be set multiple times]
-    --space         Use space indent instead of tabs  [Default: 2]
-    --no-semicolon  Prevent use of semicolons
-    --plugin        Include third-party plugins  [Can be set multiple times]
-    --extend        Extend defaults with a custom config  [Can be set multiple times]
-    --open          Open files with issues in your editor
-    --quiet         Show only errors and no warnings
-    --extension     Additional extension to lint [Can be set multiple times]
-    --no-esnext     Don't enforce ES2015+ rules
+	  --init                   Add XO to your project
+	  --fix                    Automagically fix issues
+	  --reporter               Reporter to use
+	  --stdin                  Validate/fix code from stdin
+	  --env                    Environment preset  [Can be set multiple times]
+	  --global                 Global variable  [Can be set multiple times]
+	  --ignore                 Additional paths to ignore  [Can be set multiple times]
+	  --space                  Use space indent instead of tabs  [Default: 2]
+	  --no-semicolon           Prevent use of semicolons
+	  --plugin                 Include third-party plugins  [Can be set multiple times]
+	  --skip-default-extenders Do not add the default extenders
+	  --extend                 Extend defaults with a custom config  [Can be set multiple times]
+	  --open                   Open files with issues in your editor
+	  --quiet                  Show only errors and no warnings
+	  --extension              Additional extension to lint [Can be set multiple times]
+	  --no-esnext              Don't enforce ES2015+ rules
 
   Examples
     $ xo
@@ -200,6 +201,13 @@ Set it to `false` to enforce no-semicolon style.
 Type: `Array`
 
 Include third-party [plugins](http://eslint.org/docs/user-guide/configuring.html#configuring-plugins).
+
+### skipDefaultExtenders
+
+Type: `boolean`<br>
+Default: `false`
+
+Set it to `true` to not include default extenders. Note that this does not affect the value of `esnext`.
 
 ### extends
 

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -52,7 +52,6 @@ test('buildConfig: esnext', t => {
 });
 
 test('buildConfig: skip-default-extenders', t => {
-
 	const config = manager.buildConfig({
 		esnext: false,
 		skipDefaultExtenders: true,

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -51,6 +51,25 @@ test('buildConfig: esnext', t => {
 	t.is(config.baseConfig.extends[0], 'xo');
 });
 
+test('buildConfig: skip-default-extenders', t => {
+
+	const config = manager.buildConfig({
+		esnext: false,
+		skipDefaultExtenders: true,
+		extends: [
+			'plugin:foo/bar',
+			'eslint-config-foo-bar',
+			'foo-bar-two'
+		]
+	});
+
+	t.deepEqual(config.baseConfig.extends, [
+		'plugin:foo/bar',
+		'cwd/eslint-config-foo-bar',
+		'cwd/eslint-config-foo-bar-two'
+	]);
+});
+
 test('buildConfig: space: true', t => {
 	const config = manager.buildConfig({space: true});
 	t.deepEqual(config.rules.indent, ['error', 2, {SwitchCase: 1}]);


### PR DESCRIPTION
Related issue: #182

## Changes
Provide a flag (`skip-default-extenders`) that when turned on it will skip the default extenders. This flag will be `false` by default, so it will still respect the zero-config mantra of the plugin
