### PR TITLE
Cache node_modules to speed up builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - '6'
   - '4'
+cache:
+  directories:
+    - node_modules
 before_install:
   - npm i -g npm
 after_success: npm run coveralls


### PR DESCRIPTION
Should save about 30 seconds per build.