### PR TITLE
Handle negative gitignore patterns correctly

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,3 @@
 # This is a test .gitignore.
 foo/
+!bar.js

--- a/test/bar/.gitignore
+++ b/test/bar/.gitignore
@@ -1,1 +1,2 @@
 foo.js
+!bar.js

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -173,9 +173,10 @@ test('groupConfigs', t => {
 });
 
 test('gitignore', t => {
-	const result = manager.getIgnores({});
-	t.not(result.ignores.indexOf(path.join('foo', '**')), -1);
-	t.not(result.ignores.indexOf(path.join('bar', 'foo.js')), -1);
+	const ignores = manager.getGitIgnores({});
+	t.not(ignores.indexOf('!' + path.join('foo', '**')), -1);
+	t.not(ignores.indexOf('!' + path.join('bar', 'foo.js')), -1);
+	t.not(ignores.indexOf(path.join('bar', 'bar.js')), -1);
 });
 
 test('ignore ignored .gitignore', t => {
@@ -185,9 +186,8 @@ test('ignore ignored .gitignore', t => {
 		]
 	};
 
-	const result = manager.getIgnores(opts);
-
-	t.is(result.ignores.indexOf(path.join('bar', 'foobar', 'bar.js')), -1);
+	const ignores = manager.getGitIgnores(opts);
+	t.is(ignores.indexOf('!' + path.join('bar', 'foobar', 'bar.js')), -1);
 });
 
 test('mergeWithPkgConf: use child if closest', t => {


### PR DESCRIPTION
*  split out getGitIgnores from getIgnores
*  adapt test cases accordingly
*  extend gitignore test case with negative pattern
*  invert gitignore patterns and feed sotred as glob instead of opts.ignore

fix #154