### PR TITLE
Add tests for multiple negated gitignore patterns

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -160,6 +160,14 @@ test('.lintText() - do not lint gitignored files in file with negative gitignore
 	t.is(results[0].errorCount, 0);
 });
 
+test('.lintText() - multiple negative patterns should act as positive patterns', async t => {
+	const cwd = path.join(__dirname, 'fixtures', 'gitignore-multiple-negation');
+	const filename = path.join(cwd, '!!!unicorn.js');
+	const text = await readFile(filename, 'utf-8');
+	const {results} = fn.lintText(text, {filename, cwd});
+	t.is(results[0].errorCount, 0);
+});
+
 test('.lintText() - lint negatively gitignored files', async t => {
 	const cwd = path.join(__dirname, 'fixtures/negative-gitignore');
 	const glob = path.posix.join(cwd, '*');
@@ -241,4 +249,13 @@ test('.lintFiles() - do not lint inapplicable negatively gitignored files', asyn
 	const {results} = await fn.lintFiles(glob, {cwd});
 
 	t.is(results.some(r => r.filePath === negative), false);
+});
+
+test('.lintFiles() - multiple negative patterns should act as positive patterns', async t => {
+	const cwd = path.join(__dirname, 'fixtures', 'gitignore-multiple-negation');
+	const {results} = await fn.lintFiles('**/*', {cwd});
+	const paths = results.map(r => path.basename(r.filePath));
+	paths.sort();
+
+	t.deepEqual(paths, ['!!unicorn.js', '!unicorn.js']);
 });

--- a/test/fixtures/gitignore-multiple-negation/!!!unicorn.js
+++ b/test/fixtures/gitignore-multiple-negation/!!!unicorn.js
@@ -1,0 +1,1 @@
+console.log('no semicolon')

--- a/test/fixtures/gitignore-multiple-negation/!!unicorn.js
+++ b/test/fixtures/gitignore-multiple-negation/!!unicorn.js
@@ -1,0 +1,1 @@
+console.log('no semicolon')

--- a/test/fixtures/gitignore-multiple-negation/!unicorn.js
+++ b/test/fixtures/gitignore-multiple-negation/!unicorn.js
@@ -1,0 +1,1 @@
+console.log('no semicolon')

--- a/test/fixtures/gitignore-multiple-negation/.gitignore
+++ b/test/fixtures/gitignore-multiple-negation/.gitignore
@@ -1,0 +1,3 @@
+*.js
+!!unicorn.js
+!!!unicorn.js

--- a/test/fixtures/gitignore-multiple-negation/unicorn.js
+++ b/test/fixtures/gitignore-multiple-negation/unicorn.js
@@ -1,0 +1,1 @@
+console.log('no semicolon')


### PR DESCRIPTION
Multiple negated gitignore patterns (e.g. `!!unicorn.js`) were interpreted wrongly before #204. These tests ensure correct interpretation of future releases.

**Note:** Tests are failing because of #216 