### PR TITLE
Bump meow dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"has-flag": "^2.0.0",
 		"ignore": "^3.2.6",
 		"lodash.isequal": "^4.4.0",
-		"meow": "^3.4.2",
+		"meow": "^3.7.0",
 		"multimatch": "^2.1.0",
 		"open-editor": "^1.0.1",
 		"path-exists": "^3.0.0",


### PR DESCRIPTION
I've seen there was a dependency bump rejected not long ago, but I had errors when running `xo` after `yarn install --flat` with this dep pulling `"redent": "^1.0.0"` instead of the latest and creating a waterfall of outdated deps which eventually culminated in a breaking call to `indent-string` coming from `strip-indent` and throwing:

 ```javascript
TypeError: Expected `count` to be a `number`, got `string`
```