### PR TITLE
Update outdated note about config overrides

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Uses [ESLint](http://eslint.org) underneath, so issues regarding rules should be
 - Zero-config, but [configurable when needed](#config).
 - Enforces readable code, because you read more code than you write.
 - No need to specify file paths to lint as it lints all JS files except for [commonly ignored paths](#ignores).
-- [Config overrides per files/globs.](#config-overrides) *(ESLint doesn't support this)*
+- [Config overrides per files/globs.](#config-overrides)
 - Includes many useful ESLint plugins, like [`unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn), [`import`](https://github.com/benmosher/eslint-plugin-import), [`ava`](https://github.com/avajs/eslint-plugin-ava), and more.
 - Caches results between runs for much better performance.
 - Super simple to add XO to a project with `$ xo --init`.


### PR DESCRIPTION
Hello :wave:

Starting in ESLint v4.1.0, ESLint now supports [config overrides based on glob patterns](http://eslint.org/docs/user-guide/configuring#configuration-based-on-glob-patterns) (with a design largely inspired by xo, I think). This commit updates the readme to remove the note about ESLint not supporting config overrides.