### PR TITLE
Add `flow-typed` dir to ignored path list

### DIFF
--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -13,6 +13,7 @@ const getGitIgnoreFilter = require('./gitignore').getGitIgnoreFilter;
 const DEFAULT_IGNORE = [
 	'**/node_modules/**',
 	'**/bower_components/**',
+	'flow-typed/**',
 	'coverage/**',
 	'{tmp,temp}/**',
 	'**/*.min.js',


### PR DESCRIPTION
I know XO doesn't lint anything about `flow` by default which is great!

But I think it's a good idea to make XO ignores all files inside the `flow-typed` dir (generated by [flow-typed](https://github.com/flowtype/flow-typed)) by default