### PR TITLE
Add eslint-plugin-node

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -78,7 +78,7 @@ module.exports = {
 		// Disabled as the rule doesn't allow to exclude compiled sources
 		// 'node/no-unsupported-features': 'error',
 		'node/process-exit-as-throw': 'error',
-		// Disabled as the rule doesn't exclude scripts executed with `node` but not referenced in "bin" (i.e main.js)
+		// Disabled as the rule doesn't exclude scripts executed with `node` but not referenced in "bin". See https://github.com/mysticatea/eslint-plugin-node/issues/96
 		// 'node/shebang': 'error',
 		'node/no-deprecated-api': 'error',
 		'node/exports-style': ['error', 'module.exports']

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -15,7 +15,8 @@ module.exports = {
 		'ava',
 		'unicorn',
 		'promise',
-		'import'
+		'import',
+		'node'
 	],
 	extends: [
 		'plugin:ava/recommended',
@@ -64,6 +65,22 @@ module.exports = {
 		'import/prefer-default-export': 'error',
 		'import/no-unassigned-import': ['error', {
 			allow: ['babel-polyfill', '@babel/polyfill', 'babel-register', '@babel/register']
-		}]
+		}],
+		// Redundant with import/no-extraneous-dependencies
+		// 'node/no-extraneous-import': 'error',
+		// 'node/no-extraneous-require': 'error',
+		// Redundant with import/no-unresolved
+		// 'node/no-missing-import': 'error',
+		// 'node/no-missing-require': 'error',
+		'node/no-unpublished-bin': 'error',
+		'node/no-unpublished-import': ['error', {allowModules: ['electron', 'atom']}],
+		'node/no-unpublished-require': ['error', {allowModules: ['electron', 'atom']}],
+		// Disabled as the rule doesn't allow to exclude compiled sources
+		// 'node/no-unsupported-features': 'error',
+		'node/process-exit-as-throw': 'error',
+		// Disable as the rule doesn't exclude scripts executed with node but not referenced in "bin" (i.e main.js)
+		// 'node/shebang': 'error',
+		'node/no-deprecated-api': 'error',
+		'node/exports-style': ['error', 'module.exports', {allowBatchAssign: true}]
 	}
 };

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -54,7 +54,7 @@ module.exports = {
 		// 'import/unambiguous': 'error',
 		// enable this sometime in the future when Node.js has ES2015 module support
 		// 'import/no-commonjs': 'error',
-		// looks useful, but too unstable at the moment
+		// Looks useful, but too unstable at the moment
 		// 'import/no-deprecated': 'error',
 		'import/no-extraneous-dependencies': 'error',
 		'import/no-mutable-exports': 'error',
@@ -78,7 +78,7 @@ module.exports = {
 		// Disabled as the rule doesn't allow to exclude compiled sources
 		// 'node/no-unsupported-features': 'error',
 		'node/process-exit-as-throw': 'error',
-		// Disable as the rule doesn't exclude scripts executed with node but not referenced in "bin" (i.e main.js)
+		// Disabled as the rule doesn't exclude scripts executed with `node` but not referenced in "bin" (i.e main.js)
 		// 'node/shebang': 'error',
 		'node/no-deprecated-api': 'error',
 		'node/exports-style': ['error', 'module.exports', {allowBatchAssign: true}]

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -81,6 +81,6 @@ module.exports = {
 		// Disabled as the rule doesn't exclude scripts executed with `node` but not referenced in "bin" (i.e main.js)
 		// 'node/shebang': 'error',
 		'node/no-deprecated-api': 'error',
-		'node/exports-style': ['error', 'module.exports', {allowBatchAssign: true}]
+		'node/exports-style': ['error', 'module.exports']
 	}
 };

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const runEslint = (paths, opts) => {
 	return processReport(report, opts);
 };
 
-exports.lintText = (str, opts) => {
+module.exports.lintText = (str, opts) => {
 	opts = optionsManager.preprocess(opts);
 
 	if (opts.overrides && opts.overrides.length > 0) {
@@ -84,7 +84,7 @@ exports.lintText = (str, opts) => {
 	return processReport(report, opts);
 };
 
-exports.lintFiles = (patterns, opts) => {
+module.exports.lintFiles = (patterns, opts) => {
 	opts = optionsManager.preprocess(opts);
 
 	const isEmptyPatterns = patterns.length === 0;
@@ -118,6 +118,6 @@ exports.lintFiles = (patterns, opts) => {
 	});
 };
 
-exports.getFormatter = eslint.CLIEngine.getFormatter;
-exports.getErrorResults = eslint.CLIEngine.getErrorResults;
-exports.outputFixes = eslint.CLIEngine.outputFixes;
+module.exports.getFormatter = eslint.CLIEngine.getFormatter;
+module.exports.getErrorResults = eslint.CLIEngine.getErrorResults;
+module.exports.outputFixes = eslint.CLIEngine.outputFixes;

--- a/lib/gitignore.js
+++ b/lib/gitignore.js
@@ -38,4 +38,4 @@ const getGitIgnoreFilter = opts => {
 	return p => !i.ignores(slash(path.relative(cwd, p)));
 };
 
-exports.getGitIgnoreFilter = getGitIgnoreFilter;
+module.exports.getGitIgnoreFilter = getGitIgnoreFilter;

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -249,15 +249,15 @@ const preprocess = opts => {
 	return opts;
 };
 
-exports.DEFAULT_IGNORE = DEFAULT_IGNORE;
-exports.DEFAULT_CONFIG = DEFAULT_CONFIG;
-exports.mergeWithPkgConf = mergeWithPkgConf;
-exports.normalizeOpts = normalizeOpts;
-exports.buildConfig = buildConfig;
-exports.findApplicableOverrides = findApplicableOverrides;
-exports.mergeApplicableOverrides = mergeApplicableOverrides;
-exports.groupConfigs = groupConfigs;
-exports.preprocess = preprocess;
-exports.emptyOptions = emptyOptions;
-exports.getIgnores = getIgnores;
-exports.getGitIgnoreFilter = getGitIgnoreFilter;
+module.exports.DEFAULT_IGNORE = DEFAULT_IGNORE;
+module.exports.DEFAULT_CONFIG = DEFAULT_CONFIG;
+module.exports.mergeWithPkgConf = mergeWithPkgConf;
+module.exports.normalizeOpts = normalizeOpts;
+module.exports.buildConfig = buildConfig;
+module.exports.findApplicableOverrides = findApplicableOverrides;
+module.exports.mergeApplicableOverrides = mergeApplicableOverrides;
+module.exports.groupConfigs = groupConfigs;
+module.exports.preprocess = preprocess;
+module.exports.emptyOptions = emptyOptions;
+module.exports.getIgnores = getIgnores;
+module.exports.getGitIgnoreFilter = getGitIgnoreFilter;

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
 		"eslint-plugin-ava": "^4.2.0",
 		"eslint-plugin-import": "^2.0.0",
 		"eslint-plugin-no-use-extend-native": "^0.3.2",
+		"eslint-plugin-node": "^5.2.1",
 		"eslint-plugin-promise": "^3.6.0",
 		"eslint-plugin-unicorn": "^2.1.0",
 		"get-stdin": "^5.0.0",

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Uses [ESLint](http://eslint.org) underneath, so issues regarding rules should be
 - Enforces readable code, because you read more code than you write.
 - No need to specify file paths to lint as it lints all JS files except for [commonly ignored paths](#ignores).
 - [Config overrides per files/globs.](#config-overrides)
-- Includes many useful ESLint plugins, like [`unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn), [`import`](https://github.com/benmosher/eslint-plugin-import), [`ava`](https://github.com/avajs/eslint-plugin-ava), and more.
+- Includes many useful ESLint plugins, like [`unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn), [`import`](https://github.com/benmosher/eslint-plugin-import), [`ava`](https://github.com/avajs/eslint-plugin-ava), [`node`](https://github.com/mysticatea/eslint-plugin-node) and more.
 - Caches results between runs for much better performance.
 - Super simple to add XO to a project with `$ xo --init`.
 - Fix many issues automagically with `$ xo --fix`.


### PR DESCRIPTION
Fixes #123

Add the following rules:

| Rule ID                                                                                                                     | Description                                                       |
| --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [no-unpublished-bin](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unpublished-bin.md)         | Disallow 'bin' files which are ignored by npm                     |
| [no-unpublished-import](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unpublished-import.md)   | Disallow `import` declarations of private things                  |
| [no-unpublished-require](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unpublished-require.md) | Disallow `require()` expressions of private things                |
| [process-exit-as-throw](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/process-exit-as-throw.md)   | Make `process.exit()` expressions the same code path as `throw`   |
| [no-deprecated-api](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features.md)     | Disallow unsupported ECMAScript features on the specified version |
| [exports-style](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/exports-style.md)                   | Enforce either module.exports or exports                          |

The other rules provided are disabled for the following reasons:

| Rule ID                                                                                                                       | Reason for disabling                                                                  |
| ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [no-extraneous-import](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-extraneous-import.md)       | Redundant with `import/no-extraneous-dependencies`                                    |
| [no-extraneous-require](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-extraneous-require.md)     | Redundant with `import/no-extraneous-dependencies`                                    |
| [no-missing-import](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-missing-import.md)             | Redundant with `import/no-unresolved`                                                 |
| [no-missing-require](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-missing-require.md)           | Redundant with `import/no-unresolved`                                                 |
| [no-unsupported-features](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features.md) | Doesn't allow to exclude compiled sources                                             |
| [shebang](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/shebang.md)                                 | Doesn't exclude scripts executed with node but not referenced in "bin" (i.e main.js)  |
| ~~[exports-style](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/exports-style.md)~~                 | ~~Too restrictive, forces to use either `modules.exports` or `exports` but not both~~ |

Let me know if I should make changes in the rules enabled/disabled or in the configuration.
