### PR TITLE
Exclude babel-register and babel-polyfill from no-unassigned-import

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -62,6 +62,8 @@ module.exports = {
 		'import/no-unresolved': ['error', {commonjs: true}],
 		'import/order': 'error',
 		'import/prefer-default-export': 'error',
-		'import/no-unassigned-import': 'error'
+		'import/no-unassigned-import': ['error', {
+			allow: ['babel-polyfill', '@babel/polyfill', 'babel-register', '@babel/register']
+		}]
 	}
 };


### PR DESCRIPTION
[babel-polyfill](https://babeljs.io/docs/usage/polyfill/) and [babel-register](https://babeljs.io/docs/usage/babel-register/) are common modules that doesn't need to assigned.

It would be convenient to have them ignored by the [import/no-unassigned-import](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unassigned-import.md) rule.