### PR TITLE
Enforce rules based on "engines" field in package.json

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -81,6 +81,9 @@ module.exports = {
 		// Disabled as the rule doesn't exclude scripts executed with `node` but not referenced in "bin". See https://github.com/mysticatea/eslint-plugin-node/issues/96
 		// 'node/shebang': 'error',
 		'node/no-deprecated-api': 'error',
-		'node/exports-style': ['error', 'module.exports']
+		'node/exports-style': ['error', 'module.exports'],
+		// Disable by default (override `plugin:unicorn/recommended`), will be enabled if supported by the Node version
+		'unicorn/prefer-spread': 'off',
+		'unicorn/no-new-buffer': 'off'
 	}
 };

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -31,8 +31,6 @@ module.exports = {
 	rules: {
 		'no-use-extend-native/no-use-extend-native': 'error',
 		'promise/param-names': 'error',
-		// Enable this sometime in the future when Node.js has async/await support
-		// 'promise/prefer-await-to-then': 'error',
 		'promise/no-return-wrap': ['error', {allowReject: true}],
 		'promise/no-return-in-finally': 'error',
 		'import/default': 'error',

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -80,7 +80,7 @@ module.exports = {
 		// 'node/shebang': 'error',
 		'node/no-deprecated-api': 'error',
 		'node/exports-style': ['error', 'module.exports'],
-		// Disable by default (override `plugin:unicorn/recommended`), will be enabled if supported by the Node version
+		// Disabled by default (overrides `plugin:unicorn/recommended`), will be enabled if supported by the Node.js version
 		'unicorn/prefer-spread': 'off',
 		'unicorn/no-new-buffer': 'off'
 	}

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const runEslint = (paths, opts) => {
 module.exports.lintText = (str, opts) => {
 	opts = optionsManager.preprocess(opts);
 
-	if (opts.overrides && opts.overrides.length > 0 && opts.filename) {
+	if (opts.overrides && opts.overrides.length > 0) {
 		const overrides = opts.overrides;
 		delete opts.overrides;
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const runEslint = (paths, opts) => {
 module.exports.lintText = (str, opts) => {
 	opts = optionsManager.preprocess(opts);
 
-	if (opts.overrides && opts.overrides.length > 0) {
+	if (opts.overrides && opts.overrides.length > 0 && opts.filename) {
 		const overrides = opts.overrides;
 		delete opts.overrides;
 

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -8,6 +8,7 @@ const pathExists = require('path-exists');
 const pkgConf = require('pkg-conf');
 const resolveFrom = require('resolve-from');
 const prettier = require('prettier');
+const semver = require('semver');
 
 const DEFAULT_IGNORE = [
 	'**/node_modules/**',
@@ -39,6 +40,43 @@ const DEFAULT_CONFIG = {
 			path.join(__dirname, '../config/overrides.js'),
 			path.join(__dirname, '../config/plugins.js')
 		]
+	}
+};
+
+/**
+ * Define the rules that are enabled only for specific version of Node, based on `engines.node` in package.json or the `node-engine` option.
+ *
+ * The keys ae rule names and the values are an Object with a valid semver (`4.0.0` is valid `4` is not) as keys and the rule configuration as values.
+ * Each entry define the rule configuration and the minimum Node version for which to set it.
+ * The entry with the highest version that is compliant with the `engines.node`/`node-engine` range will be used.
+ *
+ * @type {Object}
+ *
+ * @example
+ * ```javascript
+ * {
+ * 	'plugin/rule': {
+ * 		'6.0.0': ['error', {prop: 'node-6-conf'}],
+ *		'8.0.0': ['error', {prop: 'node-8-conf'}]
+ * 		}
+ * }
+ *```
+ * With `engines.node` set to `>=4` the rule `plugin/rule` will not be used.
+ * With `engines.node` set to `>=6` the rule `plugin/rule` will be used with the config `{prop: 'node-6-conf'}`.
+ * With `engines.node` set to `>=8` the rule `plugin/rule` will be used with the config `{prop: 'node-8-conf'}`.
+ */
+const ENGINE_RULES = {
+	'promise/prefer-await-to-then': {
+		'8.0.0': 'error'
+	},
+	'prefer-rest-params': {
+		'6.0.0': 'error'
+	},
+	'prefer-spread': {
+		'5.0.0': 'error'
+	},
+	'prefer-destructuring': {
+		'6.0.0': ['error', {array: true, object: true}, {enforceForRenamedProperties: true}]
 	}
 };
 
@@ -88,7 +126,8 @@ const mergeWithPkgConf = opts => {
 	opts = Object.assign({cwd: process.cwd()}, opts);
 	opts.cwd = path.resolve(opts.cwd);
 	const conf = pkgConf.sync('xo', {cwd: opts.cwd, skipOnFalse: true});
-	return Object.assign({}, conf, opts);
+	const engines = pkgConf.sync('engines', {cwd: opts.cwd});
+	return Object.assign({}, conf, {engines}, opts);
 };
 
 const normalizeSpaces = opts => {
@@ -128,6 +167,17 @@ const buildConfig = opts => {
 		mergeFn
 	);
 	const spaces = normalizeSpaces(opts);
+
+	if (opts.engines && opts.engines.node && semver.validRange(opts.engines.node)) {
+		for (const rule of Object.keys(ENGINE_RULES)) {
+			// Use the rule value for the highest version that is lower or equal to the oldest version of Node supported
+			for (const minVersion of Object.keys(ENGINE_RULES[rule]).sort(semver.compare)) {
+				if (!semver.intersects(opts.engines.node, `<${minVersion}`)) {
+					config.rules[rule] = ENGINE_RULES[rule][minVersion];
+				}
+			}
+		}
+	}
 
 	if (opts.space) {
 		config.rules.indent = ['error', spaces, {SwitchCase: 1}];

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -82,11 +82,14 @@ const ENGINE_RULES = {
 	'prefer-rest-params': {
 		'6.0.0': 'error'
 	},
-	'prefer-spread': {
+	'unicorn/prefer-spread': {
 		'5.0.0': 'error'
 	},
 	'prefer-destructuring': {
 		'6.0.0': ['error', {array: true, object: true}, {enforceForRenamedProperties: true}]
+	},
+	'unicorn/no-new-buffer': {
+		'5.10.0': 'error'
 	}
 };
 

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -54,11 +54,11 @@ const DEFAULT_CONFIG = {
 };
 
 /**
- * Define the rules that are enabled only for specific version of Node, based on `engines.node` in package.json or the `node-engine` option.
+ * Define the rules that are enabled only for specific version of Node, based on `engines.node` in package.json or the `node-version` option.
  *
- * The keys ae rule names and the values are an Object with a valid semver (`4.0.0` is valid `4` is not) as keys and the rule configuration as values.
+ * The keys are rule names and the values are an Object with a valid semver (`4.0.0` is valid `4` is not) as keys and the rule configuration as values.
  * Each entry define the rule configuration and the minimum Node version for which to set it.
- * The entry with the highest version that is compliant with the `engines.node`/`node-engine` range will be used.
+ * The entry with the highest version that is compliant with the `engines.node`/`node-version` range will be used.
  *
  * @type {Object}
  *

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -30,6 +30,16 @@ const DEFAULT_EXTENSION = [
 	'jsx'
 ];
 
+const AVA_NODE_TARGET = 8;
+
+const AVA_DEFAULT_FILES = [
+	'test.js',
+	'test-*.js',
+	'test',
+	'**/__tests__',
+	'**/*.test.js'
+];
+
 const DEFAULT_CONFIG = {
 	useEslintrc: false,
 	cache: true,
@@ -325,10 +335,21 @@ const getIgnores = opts => {
 	return opts;
 };
 
+const getDefaultOverrides = opts => {
+	// Only apply if the user uses AVA, and the `engines.node` supoort Node version lower than AVA target
+	if (opts.cwd && resolveFrom.silent(opts.cwd, 'ava') && (!opts.engines || !opts.engines.node || !semver.validRange(opts.engines.node) || semver.intersects(opts.engines.node, `<${AVA_NODE_TARGET}`))) {
+		opts.overrides = arrify(opts.overrides);
+		opts.overrides.push(mergeWith({}, {files: AVA_DEFAULT_FILES}, {engines: {nodes: `>=${AVA_NODE_TARGET}`}}));
+	}
+
+	return opts;
+};
+
 const preprocess = opts => {
 	opts = mergeWithPkgConf(opts);
 	opts = normalizeOpts(opts);
 	opts = getIgnores(opts);
+	opts = getDefaultOverrides(opts);
 	opts.extensions = DEFAULT_EXTENSION.concat(opts.extensions || []);
 
 	return opts;
@@ -336,6 +357,7 @@ const preprocess = opts => {
 
 module.exports.DEFAULT_IGNORE = DEFAULT_IGNORE;
 module.exports.DEFAULT_CONFIG = DEFAULT_CONFIG;
+module.exports.AVA_DEFAULT_FILES = AVA_DEFAULT_FILES;
 module.exports.mergeWithPkgConf = mergeWithPkgConf;
 module.exports.mergeWithPrettierConf = mergeWithPrettierConf;
 module.exports.normalizeOpts = normalizeOpts;
@@ -346,3 +368,4 @@ module.exports.groupConfigs = groupConfigs;
 module.exports.preprocess = preprocess;
 module.exports.emptyOptions = emptyOptions;
 module.exports.getIgnores = getIgnores;
+module.exports.getDefaultOverrides = getDefaultOverrides;

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -30,16 +30,6 @@ const DEFAULT_EXTENSION = [
 	'jsx'
 ];
 
-const AVA_NODE_TARGET = 8;
-
-const AVA_DEFAULT_FILES = [
-	'test.js',
-	'test-*.js',
-	'test',
-	'**/__tests__',
-	'**/*.test.js'
-];
-
 const DEFAULT_CONFIG = {
 	useEslintrc: false,
 	cache: true,
@@ -338,21 +328,10 @@ const getIgnores = opts => {
 	return opts;
 };
 
-const getDefaultOverrides = opts => {
-	// Only apply if the user uses AVA, and the `engines.node` supoort Node version lower than AVA target
-	if (opts.cwd && resolveFrom.silent(opts.cwd, 'ava') && (!opts.engines || !opts.engines.node || !semver.validRange(opts.engines.node) || semver.intersects(opts.engines.node, `<${AVA_NODE_TARGET}`))) {
-		opts.overrides = arrify(opts.overrides);
-		opts.overrides.push(mergeWith({}, {files: AVA_DEFAULT_FILES}, {engines: {nodes: `>=${AVA_NODE_TARGET}`}}));
-	}
-
-	return opts;
-};
-
 const preprocess = opts => {
 	opts = mergeWithPkgConf(opts);
 	opts = normalizeOpts(opts);
 	opts = getIgnores(opts);
-	opts = getDefaultOverrides(opts);
 	opts.extensions = DEFAULT_EXTENSION.concat(opts.extensions || []);
 
 	return opts;
@@ -360,7 +339,6 @@ const preprocess = opts => {
 
 module.exports.DEFAULT_IGNORE = DEFAULT_IGNORE;
 module.exports.DEFAULT_CONFIG = DEFAULT_CONFIG;
-module.exports.AVA_DEFAULT_FILES = AVA_DEFAULT_FILES;
 module.exports.mergeWithPkgConf = mergeWithPkgConf;
 module.exports.mergeWithPrettierConf = mergeWithPrettierConf;
 module.exports.normalizeOpts = normalizeOpts;
@@ -371,4 +349,3 @@ module.exports.groupConfigs = groupConfigs;
 module.exports.preprocess = preprocess;
 module.exports.emptyOptions = emptyOptions;
 module.exports.getIgnores = getIgnores;
-module.exports.getDefaultOverrides = getDefaultOverrides;

--- a/lib/options-manager.js
+++ b/lib/options-manager.js
@@ -67,7 +67,7 @@ const DEFAULT_CONFIG = {
  */
 const ENGINE_RULES = {
 	'promise/prefer-await-to-then': {
-		'8.0.0': 'error'
+		'7.6.0': 'error'
 	},
 	'prefer-rest-params': {
 		'6.0.0': 'error'

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const updateNotifier = require('update-notifier');
 const getStdin = require('get-stdin');
 const meow = require('meow');
 const formatterPretty = require('eslint-formatter-pretty');
+const semver = require('semver');
 const openReport = require('./lib/open-report');
 const xo = require('.');
 
@@ -21,6 +22,7 @@ const cli = meow(`
 	  --space           Use space indent instead of tabs  [Default: 2]
 	  --no-semicolon    Prevent use of semicolons
 	  --prettier        Conform to Prettier code style
+	  --node-version    Range of Node version to support
 	  --plugin          Include third-party plugins  [Can be set multiple times]
 	  --extend          Extend defaults with a custom config  [Can be set multiple times]
 	  --open            Open files with issues in your editor
@@ -75,6 +77,9 @@ const cli = meow(`
 		// },
 		prettier: {
 			type: 'boolean'
+		},
+		nodeVersion: {
+			type: 'string'
 		},
 		plugin: {
 			type: 'string'
@@ -134,6 +139,17 @@ const log = report => {
 if (input[0] === '-') {
 	opts.stdin = true;
 	input.shift();
+}
+
+if (opts.nodeVersion) {
+	if (opts.nodeVersion === 'false') {
+		opts.engines = false;
+	} else if (semver.validRange(opts.nodeVersion)) {
+		opts.engines = {node: opts.nodeVersion};
+	} else {
+		console.error('The `node-engine` option must be a valid semver range (for example `>=4`)');
+		process.exit(1);
+	}
 }
 
 if (opts.init) {

--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ const cli = meow(`
 	  --space           Use space indent instead of tabs  [Default: 2]
 	  --no-semicolon    Prevent use of semicolons
 	  --prettier        Conform to Prettier code style
-	  --node-version    Range of Node version to support
+	  --node-version    Range of Node.js version to support
 	  --plugin          Include third-party plugins  [Can be set multiple times]
 	  --extend          Extend defaults with a custom config  [Can be set multiple times]
 	  --open            Open files with issues in your editor

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
 		"prettier": "~1.10.2",
 		"resolve-cwd": "^2.0.0",
 		"resolve-from": "^4.0.0",
+		"semver": "^5.4.1",
 		"slash": "^1.0.0",
 		"update-notifier": "^2.1.0",
 		"xo-init": "^0.6.0"

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Uses [ESLint](http://eslint.org) underneath, so issues regarding rules should be
 - No need to specify file paths to lint as it lints all JS files except for [commonly ignored paths](#ignores).
 - [Config overrides per files/globs.](#config-overrides)
 - Includes many useful ESLint plugins, like [`unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn), [`import`](https://github.com/benmosher/eslint-plugin-import), [`ava`](https://github.com/avajs/eslint-plugin-ava), [`node`](https://github.com/mysticatea/eslint-plugin-node) and more.
-- Automatically enable or disable rules based on the [engines](https://docs.npmjs.com/files/package.json#engines) of your `package.json`.
+- Automatically toggles rules based on the [engines](https://docs.npmjs.com/files/package.json#engines) field in your `package.json`.
 - Caches results between runs for much better performance.
 - Super simple to add XO to a project with `$ xo --init`.
 - Fix many issues automagically with `$ xo --fix`.

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ Uses [ESLint](http://eslint.org) underneath, so issues regarding rules should be
 - No need to specify file paths to lint as it lints all JS files except for [commonly ignored paths](#ignores).
 - [Config overrides per files/globs.](#config-overrides)
 - Includes many useful ESLint plugins, like [`unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn), [`import`](https://github.com/benmosher/eslint-plugin-import), [`ava`](https://github.com/avajs/eslint-plugin-ava), [`node`](https://github.com/mysticatea/eslint-plugin-node) and more.
+- Automatically enable or disable rules based on the [engines](https://docs.npmjs.com/files/package.json#engines) of your `package.json`.
 - Caches results between runs for much better performance.
 - Super simple to add XO to a project with `$ xo --init`.
 - Fix many issues automagically with `$ xo --fix`.
@@ -61,6 +62,7 @@ $ xo --help
     --space           Use space indent instead of tabs  [Default: 2]
     --no-semicolon    Prevent use of semicolons
     --prettier        Conform to Prettier code style
+    --node-version    Range of Node version to support
     --plugin          Include third-party plugins  [Can be set multiple times]
     --extend          Extend defaults with a custom config  [Can be set multiple times]
     --open            Open files with issues in your editor
@@ -206,6 +208,14 @@ Default: `false`
 
 Format code with [Prettier](https://github.com/prettier/prettier). The [Prettier options](https://prettier.io/docs/en/options.html) will be read from the [Prettier config](https://prettier.io/docs/en/configuration.html)
 
+### nodeVersion
+
+Type: `string`, `boolean`<br>
+Default: value of `engines.node` key in the project `package.json`
+
+Enable rules specific to the Node versions within the range configured.
+If set to `false` no rules specific to a Node version will be enable.
+
 ### plugins
 
 Type: `Array`
@@ -302,6 +312,25 @@ If you have a directory structure with nested `package.json` files and you want 
 ### Monorepo
 
 Put a `package.json` with your config at the root and add `"xo": false` to the `package.json` in your bundled packages.
+
+### Transpilation
+
+If some files in your project are transpiled in order to support an older Node version you can use the [Config Overrides](#config-overrides) option to set a specific [nodeVersion](#nodeversion) target to these files.
+
+For example, if your project targets Node 4 (your `package.json` is configured with `engines.node` to `>=4`) and you are using [AVA](https://github.com/avajs/ava), then your test files are automatically transpiled. You can override `nodeVersion` for the tests files:
+
+```json
+{
+	"xo": {
+		"overrides": [
+			{
+				"files": "{test,tests,spec,__tests__}/**/*.js",
+				"nodeVersion": ">=9"
+			}
+		]
+	}
+}
+```
 
 
 ## FAQ

--- a/readme.md
+++ b/readme.md
@@ -313,6 +313,25 @@ If you have a directory structure with nested `package.json` files and you want 
 
 Put a `package.json` with your config at the root and add `"xo": false` to the `package.json` in your bundled packages.
 
+### Transpilation
+
+If some files in your project are transpiled in order to support an older Node version you can use the [Config Overrides](#config-overrides) option to set a specific [nodeVersion](#nodeversion) target to these files.
+
+For example, if your project targets Node 4 (your `package.json` is configured with `engines.node` to `>=4`) and you are using [AVA](https://github.com/avajs/ava), then your test files are automatically transpiled. You can override `nodeVersion` for the tests files:
+
+```json
+{
+	"xo": {
+		"overrides": [
+			{
+				"files": "{test,tests,spec,__tests__}/**/*.js",
+				"nodeVersion": ">=9"
+			}
+		]
+	}
+}
+```
+
 
 ## FAQ
 

--- a/readme.md
+++ b/readme.md
@@ -313,25 +313,6 @@ If you have a directory structure with nested `package.json` files and you want 
 
 Put a `package.json` with your config at the root and add `"xo": false` to the `package.json` in your bundled packages.
 
-### Transpilation
-
-If some files in your project are transpiled in order to support an older Node version you can use the [Config Overrides](#config-overrides) option to set a specific [nodeVersion](#nodeversion) target to these files.
-
-For example, if your project targets Node 4 (your `package.json` is configured with `engines.node` to `>=4`) and you are using [AVA](https://github.com/avajs/ava), then your test files are automatically transpiled. You can override `nodeVersion` for the tests files:
-
-```json
-{
-	"xo": {
-		"overrides": [
-			{
-				"files": "{test,tests,spec,__tests__}/**/*.js",
-				"nodeVersion": ">=9"
-			}
-		]
-	}
-}
-```
-
 
 ## FAQ
 

--- a/readme.md
+++ b/readme.md
@@ -315,9 +315,9 @@ Put a `package.json` with your config at the root and add `"xo": false` to the `
 
 ### Transpilation
 
-If some files in your project are transpiled in order to support an older Node version you can use the [Config Overrides](#config-overrides) option to set a specific [nodeVersion](#nodeversion) target to these files.
+If some files in your project are transpiled in order to support an older Node.js version, you can use the [config overrides](#config-overrides) option to set a specific [`nodeVersion`](#nodeversion) target for these files.
 
-For example, if your project targets Node 4 (your `package.json` is configured with `engines.node` to `>=4`) and you are using [AVA](https://github.com/avajs/ava), then your test files are automatically transpiled. You can override `nodeVersion` for the tests files:
+For example, if your project targets Node.js 4 (your `package.json` is configured with `engines.node` set to `>=4`) and you are using [AVA](https://github.com/avajs/ava), then your test files are automatically transpiled. You can override `nodeVersion` for the tests files:
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Uses [ESLint](http://eslint.org) underneath, so issues regarding rules should be
 - No need to specify file paths to lint as it lints all JS files except for [commonly ignored paths](#ignores).
 - [Config overrides per files/globs.](#config-overrides)
 - Includes many useful ESLint plugins, like [`unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn), [`import`](https://github.com/benmosher/eslint-plugin-import), [`ava`](https://github.com/avajs/eslint-plugin-ava), [`node`](https://github.com/mysticatea/eslint-plugin-node) and more.
-- Automatically toggles rules based on the [engines](https://docs.npmjs.com/files/package.json#engines) field in your `package.json`.
+- Automatically enables rules based on the [`engines`](https://docs.npmjs.com/files/package.json#engines) field in your `package.json`.
 - Caches results between runs for much better performance.
 - Super simple to add XO to a project with `$ xo --init`.
 - Fix many issues automagically with `$ xo --fix`.

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ $ xo --help
     --space           Use space indent instead of tabs  [Default: 2]
     --no-semicolon    Prevent use of semicolons
     --prettier        Conform to Prettier code style
-    --node-version    Range of Node version to support
+    --node-version    Range of Node.js version to support
     --plugin          Include third-party plugins  [Can be set multiple times]
     --extend          Extend defaults with a custom config  [Can be set multiple times]
     --open            Open files with issues in your editor
@@ -211,10 +211,10 @@ Format code with [Prettier](https://github.com/prettier/prettier). The [Prettier
 ### nodeVersion
 
 Type: `string`, `boolean`<br>
-Default: value of `engines.node` key in the project `package.json`
+Default: Value of the `engines.node` key in the project `package.json`
 
-Enable rules specific to the Node versions within the range configured.
-If set to `false` no rules specific to a Node version will be enable.
+Enable rules specific to the Node.js versions within the configured range.
+If set to `false`, no rules specific to a Node.js version will be enabled.
 
 ### plugins
 

--- a/test/fixtures/engines/package.json
+++ b/test/fixtures/engines/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "application-name",
+  "version": "0.0.1",
+  "engines": {
+    "node": ">=6"
+  }
+}

--- a/test/fixtures/engines/package.json
+++ b/test/fixtures/engines/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "application-name",
-  "version": "0.0.1",
-  "engines": {
-    "node": ">=6"
-  }
+	"name": "application-name",
+	"version": "0.0.1",
+	"engines": {
+		"node": ">=6"
+	}
 }

--- a/test/main.js
+++ b/test/main.js
@@ -94,3 +94,9 @@ test('init option', async t => {
 	const packageJson = fs.readFileSync(filepath, 'utf8');
 	t.deepEqual(JSON.parse(packageJson).scripts, {test: 'xo'});
 });
+
+test('invalid node-engine option', async t => {
+	const filepath = await tempWrite('console.log()\n', 'x.js');
+	const err = await t.throws(main(['--node-version', 'v', filepath]));
+	t.is(err.code, 1);
+});

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -382,24 +382,3 @@ test('mergeWithPkgConf: XO engine options false supersede package.json\'s', t =>
 	const expected = Object.assign({}, {engines: false}, {cwd});
 	t.deepEqual(result, expected);
 });
-
-test('getDefaultOverrides: add AVA override if Node.js engine <=8', t => {
-	const cwd = path.resolve('fixtures', 'engines');
-	const config = manager.getDefaultOverrides({cwd, engines: {node: '>=4'}});
-
-	t.deepEqual(config.overrides, [{engines: {nodes: '>=8'}, files: manager.AVA_DEFAULT_FILES}]);
-});
-
-test('getDefaultOverrides: add AVA override is Node.js engine undefined', t => {
-	const cwd = path.resolve('fixtures', 'engines');
-	const config = manager.getDefaultOverrides({cwd});
-
-	t.deepEqual(config.overrides, [{engines: {nodes: '>=8'}, files: manager.AVA_DEFAULT_FILES}]);
-});
-
-test('getDefaultOverrides: Ado not add AVA override if Node.js engine >=8', t => {
-	const cwd = path.resolve('fixtures', 'engines');
-	const config = manager.getDefaultOverrides({cwd, engines: {node: '>=8'}});
-
-	t.is(config.overrides, undefined);
-});

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -142,7 +142,7 @@ test('buildConfig: prettier: true, esnext: false', t => {
 test('buildConfig: engines: undefined', t => {
 	const config = manager.buildConfig({});
 
-	// Do not include any node version specific rules
+	// Do not include any Node.js version specific rules
 	t.is(config.rules['prefer-spread'], undefined);
 	t.is(config.rules['prefer-rest-params'], undefined);
 	t.is(config.rules['prefer-destructuring'], undefined);
@@ -152,7 +152,7 @@ test('buildConfig: engines: undefined', t => {
 test('buildConfig: engines: false', t => {
 	const config = manager.buildConfig({engines: false});
 
-	// Do not include any node version specific rules
+	// Do not include any Node.js version specific rules
 	t.is(config.rules['prefer-spread'], undefined);
 	t.is(config.rules['prefer-rest-params'], undefined);
 	t.is(config.rules['prefer-destructuring'], undefined);
@@ -162,7 +162,7 @@ test('buildConfig: engines: false', t => {
 test('buildConfig: engines: invalid range', t => {
 	const config = manager.buildConfig({engines: {node: '4'}});
 
-	// Do not include any node version specific rules
+	// Do not include any Node.js version specific rules
 	t.is(config.rules['prefer-spread'], undefined);
 	t.is(config.rules['prefer-rest-params'], undefined);
 	t.is(config.rules['prefer-destructuring'], undefined);
@@ -172,52 +172,52 @@ test('buildConfig: engines: invalid range', t => {
 test('buildConfig: engines: >=4', t => {
 	const config = manager.buildConfig({engines: {node: '>=4'}});
 
-	// Do not include rules for Node 5 and above
+	// Do not include rules for Node.js 5 and above
 	t.is(config.rules['prefer-spread'], undefined);
-	// Do not include rules for Node 6 and above
+	// Do not include rules for Node.js 6 and above
 	t.is(config.rules['prefer-rest-params'], undefined);
 	t.is(config.rules['prefer-destructuring'], undefined);
-	// Do not include rules for Node 8 and above
+	// Do not include rules for Node.js 8 and above
 	t.is(config.rules['promise/prefer-await-to-then'], undefined);
 });
 
 test('buildConfig: engines: >=4.1', t => {
 	const config = manager.buildConfig({engines: {node: '>=5.1'}});
 
-	// Do not include rules for Node 5 and above
+	// Do not include rules for Node.js 5 and above
 	t.is(config.rules['prefer-spread'], 'error');
-	// Do not include rules for Node 6 and above
+	// Do not include rules for Node.js 6 and above
 	t.is(config.rules['prefer-rest-params'], undefined);
 	t.is(config.rules['prefer-destructuring'], undefined);
-	// Do not include rules for Node 8 and above
+	// Do not include rules for Node.js 8 and above
 	t.is(config.rules['promise/prefer-await-to-then'], undefined);
 });
 
 test('buildConfig: engines: >=6', t => {
 	const config = manager.buildConfig({engines: {node: '>=6'}});
 
-	// Include rules for Node 5 and above
+	// Include rules for Node.js 5 and above
 	t.is(config.rules['prefer-spread'], 'error');
-	// Include rules for Node 6 and above
+	// Include rules for Node.js 6 and above
 	t.is(config.rules['prefer-rest-params'], 'error');
 	t.deepEqual(config.rules['prefer-destructuring'], [
 		'error', {array: true, object: true}, {enforceForRenamedProperties: true}
 	]);
-	// Do not include rules for Node 8 and above
+	// Do not include rules for Node.js 8 and above
 	t.is(config.rules['promise/prefer-await-to-then'], undefined);
 });
 
 test('buildConfig: engines: >=8', t => {
 	const config = manager.buildConfig({engines: {node: '>=8'}});
 
-	// Include rules for Node 5 and above
+	// Include rules for Node.js 5 and above
 	t.is(config.rules['prefer-spread'], 'error');
-	// Include rules for Node 6 and above
+	// Include rules for Node.js 6 and above
 	t.is(config.rules['prefer-rest-params'], 'error');
 	t.deepEqual(config.rules['prefer-destructuring'], [
 		'error', {array: true, object: true}, {enforceForRenamedProperties: true}
 	]);
-	// Include rules for Node 8 and above
+	// Include rules for Node.js 8 and above
 	t.is(config.rules['promise/prefer-await-to-then'], 'error');
 });
 
@@ -383,21 +383,21 @@ test('mergeWithPkgConf: XO engine options false supersede package.json\'s', t =>
 	t.deepEqual(result, expected);
 });
 
-test('getDefaultOverrides: add AVA override if node engine <=8', t => {
+test('getDefaultOverrides: add AVA override if Node.js engine <=8', t => {
 	const cwd = path.resolve('fixtures', 'engines');
 	const config = manager.getDefaultOverrides({cwd, engines: {node: '>=4'}});
 
 	t.deepEqual(config.overrides, [{engines: {nodes: '>=8'}, files: manager.AVA_DEFAULT_FILES}]);
 });
 
-test('getDefaultOverrides: add AVA override is node engine undefined', t => {
+test('getDefaultOverrides: add AVA override is Node.js engine undefined', t => {
 	const cwd = path.resolve('fixtures', 'engines');
 	const config = manager.getDefaultOverrides({cwd});
 
 	t.deepEqual(config.overrides, [{engines: {nodes: '>=8'}, files: manager.AVA_DEFAULT_FILES}]);
 });
 
-test('getDefaultOverrides: Ado not add AVA override if node engine >=8', t => {
+test('getDefaultOverrides: Ado not add AVA override if Node.js engine >=8', t => {
 	const cwd = path.resolve('fixtures', 'engines');
 	const config = manager.getDefaultOverrides({cwd, engines: {node: '>=8'}});
 

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -173,7 +173,7 @@ test('buildConfig: engines: >=4', t => {
 	const config = manager.buildConfig({engines: {node: '>=4'}});
 
 	// Do not include rules for Node.js 5 and above
-	t.is(config.rules['prefer-spread'], undefined);
+	t.is(config.rules['unicorn/prefer-spread'], undefined);
 	// Do not include rules for Node.js 6 and above
 	t.is(config.rules['prefer-rest-params'], undefined);
 	t.is(config.rules['prefer-destructuring'], undefined);
@@ -185,7 +185,7 @@ test('buildConfig: engines: >=4.1', t => {
 	const config = manager.buildConfig({engines: {node: '>=5.1'}});
 
 	// Do not include rules for Node.js 5 and above
-	t.is(config.rules['prefer-spread'], 'error');
+	t.is(config.rules['unicorn/prefer-spread'], 'error');
 	// Do not include rules for Node.js 6 and above
 	t.is(config.rules['prefer-rest-params'], undefined);
 	t.is(config.rules['prefer-destructuring'], undefined);
@@ -197,7 +197,7 @@ test('buildConfig: engines: >=6', t => {
 	const config = manager.buildConfig({engines: {node: '>=6'}});
 
 	// Include rules for Node.js 5 and above
-	t.is(config.rules['prefer-spread'], 'error');
+	t.is(config.rules['unicorn/prefer-spread'], 'error');
 	// Include rules for Node.js 6 and above
 	t.is(config.rules['prefer-rest-params'], 'error');
 	t.deepEqual(config.rules['prefer-destructuring'], [
@@ -211,7 +211,7 @@ test('buildConfig: engines: >=8', t => {
 	const config = manager.buildConfig({engines: {node: '>=8'}});
 
 	// Include rules for Node.js 5 and above
-	t.is(config.rules['prefer-spread'], 'error');
+	t.is(config.rules['unicorn/prefer-spread'], 'error');
 	// Include rules for Node.js 6 and above
 	t.is(config.rules['prefer-rest-params'], 'error');
 	t.deepEqual(config.rules['prefer-destructuring'], [

--- a/test/options-manager.js
+++ b/test/options-manager.js
@@ -382,3 +382,24 @@ test('mergeWithPkgConf: XO engine options false supersede package.json\'s', t =>
 	const expected = Object.assign({}, {engines: false}, {cwd});
 	t.deepEqual(result, expected);
 });
+
+test('getDefaultOverrides: add AVA override if node engine <=8', t => {
+	const cwd = path.resolve('fixtures', 'engines');
+	const config = manager.getDefaultOverrides({cwd, engines: {node: '>=4'}});
+
+	t.deepEqual(config.overrides, [{engines: {nodes: '>=8'}, files: manager.AVA_DEFAULT_FILES}]);
+});
+
+test('getDefaultOverrides: add AVA override is node engine undefined', t => {
+	const cwd = path.resolve('fixtures', 'engines');
+	const config = manager.getDefaultOverrides({cwd});
+
+	t.deepEqual(config.overrides, [{engines: {nodes: '>=8'}, files: manager.AVA_DEFAULT_FILES}]);
+});
+
+test('getDefaultOverrides: Ado not add AVA override if node engine >=8', t => {
+	const cwd = path.resolve('fixtures', 'engines');
+	const config = manager.getDefaultOverrides({cwd, engines: {node: '>=8'}});
+
+	t.is(config.overrides, undefined);
+});


### PR DESCRIPTION
This allow to enable specific rules/rules configuration based on the range defined in `engines` field in `package.json` or the `nodeVersion` option.

If `nodeVersion` is set to `false` then the old behavior is resumed: no Node version specific rules are enabled.

The following rules are enable:
- `promise/prefer-await-to-then` for Node 8 and above
- `prefer-rest-params` for Node 6 and above
- `prefer-spread` for Node 5 and above
- `prefer-destructuring` for Node 6 and above

Should I add more?

We could later add [node/no-unsupported-features](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features.md) by passing the value `opts.nodeEngine` in the [version option](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features.md#version).
Unfortunately for now the `version` option of the rule accept only a specific version and not the range defined in `engines.node` or `nodeEngine`. That should be solved once mysticatea/eslint-plugin-node@846e677 get released. We could enable the rule then.

I also added a "Tips" for overriding the test when using AVA. Maybe we can make that automatic if the users have AVA in their dependencies?

Fix #266
  