### PR TITLE
Add detect-unsafe-regex rule

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -16,7 +16,8 @@ module.exports = {
 		'unicorn',
 		'promise',
 		'import',
-		'node'
+		'node',
+		'security'
 	],
 	extends: [
 		'plugin:ava/recommended',
@@ -81,6 +82,7 @@ module.exports = {
 		// Disabled as the rule doesn't exclude scripts executed with `node` but not referenced in "bin". See https://github.com/mysticatea/eslint-plugin-node/issues/96
 		// 'node/shebang': 'error',
 		'node/no-deprecated-api': 'error',
-		'node/exports-style': ['error', 'module.exports']
+		'node/exports-style': ['error', 'module.exports'],
+		'security/detect-unsafe-regex': 'error'
 	}
 };

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"eslint-plugin-node": "^5.2.1",
 		"eslint-plugin-prettier": "^2.3.1",
 		"eslint-plugin-promise": "^3.6.0",
+		"eslint-plugin-security": "^1.4.0",
 		"eslint-plugin-unicorn": "^3.0.1",
 		"get-stdin": "^5.0.0",
 		"globby": "^7.1.1",


### PR DESCRIPTION
Decided to go with just a warning for the unoptimized regex plugin since that is the example on the repo. I'll change it if you think it should be an error instead.