### PR TITLE
Add JSDoc plugin

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -16,7 +16,8 @@ module.exports = {
 		'unicorn',
 		'promise',
 		'import',
-		'node'
+		'node',
+		'jsdoc'
 	],
 	extends: [
 		'plugin:ava/recommended',
@@ -80,6 +81,9 @@ module.exports = {
 		// 'node/shebang': 'error',
 		'node/no-deprecated-api': 'error',
 		'node/exports-style': ['error', 'module.exports'],
+		'jsdoc/newline-after-description': 'warn',
+		'jsdoc/require-description-complete-sentence': 'warn',
+		'jsdoc/require-hyphen-before-param-description': 'warn',
 		// Disabled by default (overrides `plugin:unicorn/recommended`), will be enabled if supported by the Node.js version
 		'unicorn/prefer-spread': 'off',
 		'unicorn/no-new-buffer': 'off'

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
 		"eslint-formatter-pretty": "^1.0.0",
 		"eslint-plugin-ava": "^4.2.0",
 		"eslint-plugin-import": "^2.0.0",
+		"eslint-plugin-jsdoc": "^3.3.1",
 		"eslint-plugin-no-use-extend-native": "^0.3.2",
 		"eslint-plugin-node": "^5.2.1",
 		"eslint-plugin-prettier": "^2.3.1",


### PR DESCRIPTION
Related sindresorhus/eslint-config-xo#45

Fix #282

I added the plugin and rules suggested in #282. I didn't add the `--jsdoc` option for the reasons explained in [this comment](https://github.com/sindresorhus/xo/issues/282#issuecomment-356035657):

> As the `valid-jsdoc` rule is used when a JSDoc bloc is defined, in the end the `jsdoc` flag would just enable the `require-jsdoc` rule forcing to write JSDoc for every declaration in the code.

> Enforcing 100% JSDoc is not really something very common from what I see in the open source community (AFAIK ESLint is the only major project with near 100% JSDoc coverage).

> In addition, it would be difficult to find the best default config for the rule. Some might want a warning, some an error. Some might want a JSDoc block for function expression and declaration, some for declaration only etc...

> So I'm not sure adding a flag is justified for a case that is not really common, and requires additional config anyway. It's probably better to just set the rule in XO:
```json
{
  "xo": {
    "rules": {"require-jsdoc": ["warn", {...}]}
  }
}
```

@sindresorhus if you think the `--jsdoc` flag makes sense I can add it. Not sure what the `require-jsdoc` options would be though.