### PR TITLE
Revert JSDoc plugin

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -16,8 +16,7 @@ module.exports = {
 		'unicorn',
 		'promise',
 		'import',
-		'node',
-		'jsdoc'
+		'node'
 	],
 	extends: [
 		'plugin:ava/recommended',
@@ -81,9 +80,6 @@ module.exports = {
 		// 'node/shebang': 'error',
 		'node/no-deprecated-api': 'error',
 		'node/exports-style': ['error', 'module.exports'],
-		'jsdoc/newline-after-description': 'warn',
-		'jsdoc/require-description-complete-sentence': 'warn',
-		'jsdoc/require-hyphen-before-param-description': 'warn',
 		// Disabled by default (overrides `plugin:unicorn/recommended`), will be enabled if supported by the Node.js version
 		'unicorn/prefer-spread': 'off',
 		'unicorn/no-new-buffer': 'off'

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
 		"eslint-formatter-pretty": "^1.0.0",
 		"eslint-plugin-ava": "^4.2.0",
 		"eslint-plugin-import": "^2.0.0",
-		"eslint-plugin-jsdoc": "^3.3.1",
 		"eslint-plugin-no-use-extend-native": "^0.3.2",
 		"eslint-plugin-node": "^5.2.1",
 		"eslint-plugin-prettier": "^2.3.1",


### PR DESCRIPTION
Per [comment](https://github.com/sindresorhus/xo/issues/282#issuecomment-359282802) those new rules have several bugs.

```js
/**
 * Sentence with a word stating with a
 * Capital letter.
 */
```
Returns an error, even though it should be valid to break the line and sometimes the break happen before a capitalize word.

```js
/**
 * List of things:
 * - elem 1
 * - elem 2
 */
```
Returns an error even though doing a list should be perfectly valid in JSDoc.

```js
/**
 * Code example:
 * ```js
 * console.log(test)
 * ```
 */
```

Once again returns an error even though perfectly valid.

All the following situation might create an issue:
- Using capital letter in the middle of a sentence
- Using list
- Using colon (`:`) + new line to describe something
- Using code example
- Using mardown

We should remove those rules until they work properly.
@simonepri as you requested those rules in the first place, maybe you could open issues with the `eslint-plugin-jsdoc` project?
